### PR TITLE
docs: clarify product positioning and support paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Questions and discussion
+    url: https://github.com/tuannguyen8888/GraphTrace/discussions
+    about: Use Discussions for usage questions, architecture discussion, and general product feedback.
   - name: Contributor guide
     url: https://github.com/tuannguyen8888/GraphTrace/blob/main/CONTRIBUTING.md
     about: Review the branch strategy and local verification checklist before opening a pull request.
   - name: Architecture notes
     url: https://github.com/tuannguyen8888/GraphTrace/blob/main/docs/ARCHITECTURE.md
     about: Check the current architecture before proposing structural changes.
+  - name: Security policy
+    url: https://github.com/tuannguyen8888/GraphTrace/blob/main/SECURITY.md
+    about: Follow the responsible disclosure policy for security reports.

--- a/README.md
+++ b/README.md
@@ -1,66 +1,228 @@
 # GraphTrace
 
-Local-first code graph, impact analysis, and agent context for JS/TS monorepos.
+[![CI](https://github.com/tuannguyen8888/GraphTrace/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tuannguyen8888/GraphTrace/actions/workflows/ci.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](./LICENSE)
 
-## Status
+GraphTrace is a local-first code graph for JavaScript and TypeScript monorepos.
 
-GraphTrace is in active bootstrap. The current branch ships the first working vertical slice:
+It indexes your codebase into a local graph store, then exposes one query layer to three surfaces:
+
+- a CLI for engineers
+- an MCP server for coding agents
+- a local web UI for inspection
+
+The goal is simple: make a codebase easier to understand, safer to change, and easier to query without shipping your source code to a remote service by default.
+
+## Why GraphTrace Exists
+
+Modern monorepos are difficult to reason about because the information you need is split across files, frameworks, packages, routes, imports, and conventions.
+
+When a team asks questions like:
+
+- "If I change this service, what breaks?"
+- "Which route reaches this file?"
+- "What depends on this package?"
+- "How do I give an AI agent useful context without handing it the whole repo?"
+
+the answers are usually slow, manual, and inconsistent.
+
+GraphTrace is built to turn those questions into local queries against one source of truth.
+
+## Who GraphTrace Is For
+
+GraphTrace is intended for teams working in JS/TS codebases, especially monorepos, who need both human-readable and machine-readable understanding of their system.
+
+Typical users include:
+
+- application engineers doing refactors, reviews, and incident analysis
+- platform and architecture teams who need dependency and route visibility
+- engineering managers or tech leads who want safer change planning
+- AI-assisted development workflows that need scoped, local context through MCP instead of broad repo dumps
+
+## What Problems It Solves
+
+GraphTrace is designed to help with:
+
+- impact analysis before changing a file or service
+- dependency tracing across packages and modules
+- route discovery and route-to-code flow inspection
+- local code search across symbols, files, packages, and routes
+- providing structured context to AI agents through MCP
+- powering internal tooling from one graph/query backend instead of separate ad hoc scripts
+
+## How Teams Use It
+
+### 1. Change Planning
+
+Before editing a file, engineers ask GraphTrace which routes, files, and dependencies are likely to be affected.
+
+### 2. Codebase Navigation
+
+Instead of grepping blindly through a large monorepo, teams search symbols, packages, or routes from one local interface.
+
+### 3. AI Context Delivery
+
+An agent can call the MCP server to fetch targeted context such as routes, dependency edges, or impact results without reading the entire repository.
+
+### 4. Local Exploration
+
+Teams can expose the same indexed graph to the CLI, API server, and local web UI without introducing a hosted backend as a requirement.
+
+## Core Capabilities
+
+Today, GraphTrace focuses on a graph-first local engine and a thin set of interfaces on top of it.
+
+Current capabilities include:
 
 - workspace initialization
+- local indexing into a SQLite-backed graph store
+- queries for search, dependencies, impact analysis, and route flow
+- a CLI entry point
+- an MCP stdio server
+- a local HTTP server and web UI skeleton
+
+## Product Shape
+
+GraphTrace is not just an AI integration and it is not just a developer CLI.
+
+It is a shared local graph/query layer that can serve:
+
+- humans through terminal and UI workflows
+- automation through APIs
+- coding agents through MCP
+
+That is why the project is positioned as a hybrid developer tool plus agent context engine.
+
+## Architecture
+
+GraphTrace currently uses a graph-first local architecture:
+
+1. Source code is indexed into a local SQLite graph store.
+2. One query engine reads that graph and answers search, dependency, impact, and flow questions.
+3. The CLI, MCP server, local API server, and web UI all sit on top of the same local data model.
+
+This architecture keeps the system local-first, composable, and AI-optional.
+
+For more detail, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+
+## Current Status
+
+GraphTrace is in active bootstrap, not a finished platform.
+
+What is real today:
+
 - local indexing
-- query engine
-- CLI
-- MCP stdio server
-- local web UI skeleton
+- package, symbol, file, and route discovery
+- dependency and impact queries
+- MCP tool exposure
+- local web UI foundation
 
-## Principles
+What is still evolving:
 
-- local-first
+- broader framework coverage
+- production hardening
+- richer graph semantics
+- optional embeddings and semantic retrieval
+
+See [docs/ROADMAP.md](docs/ROADMAP.md) for the current sequence.
+
+## Quick Start
+
+### Requirements
+
+- Node.js 22 or newer within the supported range declared in `package.json`
+- `pnpm`
+
+### Install
+
+```bash
+pnpm install
+```
+
+### Verify the workspace
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
+```
+
+## CLI Examples
+
+Initialize GraphTrace in a workspace:
+
+```bash
+pnpm --filter graphtrace exec graphtrace init
+```
+
+Build or refresh the local index:
+
+```bash
+pnpm --filter graphtrace exec graphtrace index --full
+```
+
+Search the indexed graph:
+
+```bash
+pnpm --filter graphtrace exec graphtrace search listUsers
+```
+
+List discovered routes:
+
+```bash
+pnpm --filter graphtrace exec graphtrace routes
+```
+
+## Repository Layout
+
+```text
+apps/web              Local UI
+packages/cli          CLI surface
+packages/config       Workspace configuration
+packages/indexer      Source indexing
+packages/mcp          MCP server
+packages/query-engine Query layer
+packages/server       Local HTTP API
+packages/shared       Shared types
+packages/storage      SQLite-backed graph store
+fixtures/             Test workspaces
+```
+
+## Design Principles
+
+- local-first by default
 - open source
 - AI optional
 - static analysis first
 - one local source of truth
 
-## Workspace Layout
+## Documentation
 
-```text
-apps/web
-packages/shared
-packages/config
-packages/storage
-packages/indexer
-packages/query-engine
-packages/server
-packages/mcp
-packages/cli
-fixtures/
-```
-
-## Commands
-
-```bash
-pnpm install
-pnpm test
-pnpm typecheck
-pnpm lint
-pnpm build
-```
-
-### CLI
-
-```bash
-pnpm --filter graphtrace exec graphtrace init
-pnpm --filter graphtrace exec graphtrace index --full
-pnpm --filter graphtrace exec graphtrace search listUsers
-pnpm --filter graphtrace exec graphtrace routes
-```
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/ROADMAP.md](docs/ROADMAP.md)
+- [SECURITY.md](SECURITY.md)
+- [SUPPORT.md](SUPPORT.md)
 
 ## Contributing
 
 GraphTrace uses `main` as the stable branch for open source collaboration.
 
-- Open pull requests against `main`
-- Keep feature work on topic branches
-- Run `pnpm lint`, `pnpm typecheck`, and `pnpm test` before opening a pull request
+- open pull requests against `main`
+- keep feature work on topic branches
+- run `pnpm lint`, `pnpm typecheck`, and `pnpm test` before opening a pull request
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+
+## Support
+
+- Use GitHub Discussions for questions and design discussion
+- Use Issues for bugs and feature requests
+- Use the security policy for responsible vulnerability reporting
+
+See [SUPPORT.md](SUPPORT.md) and [SECURITY.md](SECURITY.md).
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Status
+
+GraphTrace is currently in active bootstrap.
+
+Security fixes are handled on a best-effort basis while the project is still evolving quickly, but responsible reports are welcome.
+
+## Reporting a Vulnerability
+
+Please do not open public GitHub issues for suspected security vulnerabilities.
+
+Use one of these paths instead:
+
+1. Use GitHub's private vulnerability reporting flow for this repository if the button is available.
+2. If private reporting is not available in the UI, contact the repository owner directly through GitHub before publishing details.
+
+Include:
+
+- a clear description of the issue
+- the affected version or commit
+- reproduction steps or a proof of concept
+- the potential impact
+
+The maintainer will review the report privately, confirm the issue, and coordinate a fix before public disclosure when possible.
+
+## Disclosure Expectations
+
+- Please allow reasonable time for investigation and remediation before public disclosure.
+- Once a fix is available, the project can publish a patch, mitigation guidance, or advisory as appropriate.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,38 @@
+# Support
+
+## Where To Ask What
+
+Use the channel that matches the type of request:
+
+- GitHub Discussions: usage questions, design discussion, implementation ideas
+- GitHub Issues: reproducible bugs, documentation gaps, feature requests
+- Security reporting: follow [SECURITY.md](SECURITY.md), not public issues
+
+## Before Opening an Issue
+
+Please check:
+
+- the current [README.md](README.md)
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/ROADMAP.md](docs/ROADMAP.md)
+
+## Good Bug Reports
+
+Helpful bug reports usually include:
+
+- the exact command or workflow used
+- the expected result
+- the actual result
+- relevant logs or screenshots
+- Node.js, pnpm, and OS versions
+- the repository commit or branch when the issue occurred
+
+## Good Feature Requests
+
+Helpful feature requests usually explain:
+
+- the workflow that is currently painful
+- who is affected
+- why current behavior is insufficient
+- what a useful outcome would look like

--- a/docs/superpowers/plans/2026-04-06-readme-community-polish.md
+++ b/docs/superpowers/plans/2026-04-06-readme-community-polish.md
@@ -1,0 +1,50 @@
+# README and Community Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reposition GraphTrace clearly for open source readers with a fuller README and finish the remaining community-facing repo documents.
+
+**Architecture:** Keep the product messaging honest to the current implementation: GraphTrace is a local-first code graph for JS/TS monorepos with CLI, MCP, and web surfaces. Add the missing community docs and small GitHub repo settings that support open source adoption without changing runtime code.
+
+**Tech Stack:** Markdown, GitHub repository settings, Git, GitHub CLI
+
+---
+
+## Chunk 1: Product Positioning
+
+### Task 1: Rewrite README around a hybrid product/technical story
+
+**Files:**
+- Modify: `README.md`
+- Create: `docs/superpowers/plans/2026-04-06-readme-community-polish.md`
+
+- [ ] Step 1: Rewrite the README opening so it states what GraphTrace is in plain language.
+- [ ] Step 2: Add sections for problem statement, intended users, and concrete use cases.
+- [ ] Step 3: Add a capabilities and architecture section that matches the current codebase truthfully.
+- [ ] Step 4: Add quick start, CLI examples, and links to roadmap/architecture/contributing.
+- [ ] Step 5: Review for clarity, repetition, and factual consistency with the repo.
+
+## Chunk 2: Community Docs
+
+### Task 2: Add missing open source support documents
+
+**Files:**
+- Create: `SECURITY.md`
+- Create: `SUPPORT.md`
+
+- [ ] Step 1: Add a security policy with a responsible disclosure path.
+- [ ] Step 2: Add a support guide that explains where to ask questions and where to file bugs or feature requests.
+- [ ] Step 3: Link these documents from the README where appropriate.
+
+## Chunk 3: Repo Settings and Verification
+
+### Task 3: Enable remaining community-facing repo options and merge
+
+**Files:**
+- No new code files
+
+- [ ] Step 1: Enable GitHub Discussions if it is not already enabled.
+- [ ] Step 2: Run `pnpm lint`.
+- [ ] Step 3: Run `pnpm typecheck`.
+- [ ] Step 4: Run `pnpm test`.
+- [ ] Step 5: Push the branch, open a PR into `main`, wait for `verify`, and merge after it passes.


### PR DESCRIPTION
## Summary
- rewrite the README around the product's purpose, audience, and use cases
- add SECURITY and SUPPORT docs for open source readers
- route questions toward Discussions and security reports toward the security policy

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
