### PR TITLE
chore: support oidc npm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
 
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
 
     steps:
@@ -26,6 +27,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,15 @@ pnpm build
 - Include screenshots or terminal output when the change affects UX or CLI output
 - Keep unrelated refactors out of the same pull request
 
+## Releases
+
+GraphTrace releases are managed with Changesets from `main`.
+
+- Merge the version PR that Changesets opens before expecting a publish run to succeed
+- Configure either the `NPM_TOKEN` GitHub Actions secret or npm trusted publishing for this repository
+- If using trusted publishing, keep the published package `repository.url` pointing at `https://github.com/tuannguyen8888/GraphTrace`
+- After release plumbing changes, verify `pnpm build` and `pnpm test:smoke` locally before re-running the `Release` workflow
+
 ## Issues
 
 When reporting a bug, include:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,10 @@
   },
   "files": ["dist", "README.md"],
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tuannguyen8888/GraphTrace.git"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- allow the release workflow to request an OIDC token for npm trusted publishing
- point setup-node at the npm registry during release jobs
- document the remaining npm publishing prerequisites and set the CLI package repository metadata

## Verification
- pnpm lint
- pnpm build
- pnpm test:smoke