### PR TITLE
chore: try trusted publishing without npm token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,3 @@ jobs:
           publish: pnpm publish -r --access public --no-git-checks
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the npm token from the release workflow so npm publish uses the configured trusted publisher
- keep the existing release flow unchanged otherwise to validate the minimal OIDC path first

## Test Plan
- [x] pnpm build
- [x] pnpm test:smoke
