### PR TITLE
chore: upgrade release runtime for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version: "24"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install --global npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- run the release workflow on Node 24 instead of inheriting the workspace runtime from .nvmrc
- upgrade npm in the release job so trusted publishing uses a modern npm cli

## Test Plan
- [x] pnpm build
- [x] pnpm test:smoke
