### PR TITLE
release: version packages for 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Lifecycle helpers:
 Why this helps:
 
 - gives agents a shared local MCP entry for `graphtrace mcp`
+- pins the Codex MCP working directory so GraphTrace resolves the repo-local `.graphtrace` data even when the tool launches from outside the workspace root
 - teaches agents when to use GraphTrace tools like `search_code`, `get_dependencies`, `get_impact_analysis`, and `get_status`
 - encourages narrow semantic queries before broad repository scans, which reduces wasted context and token usage
 

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @graphtrace/web
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+- Updated dependencies
+  - @graphtrace/shared@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/web",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphtrace-workspace",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # graphtrace
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphtrace",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Local-first code graph for JS/TS projects with CLI, MCP, and local web UI.",
   "type": "module",
   "main": "./dist/index.js",
@@ -12,7 +12,10 @@
   "bin": {
     "graphtrace": "./dist/bin.js"
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -12,10 +12,7 @@
   "bin": {
     "graphtrace": "./dist/bin.js"
   },
-  "files": [
-    "dist",
-    "README.md"
-  ],
+  "files": ["dist", "README.md"],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/cli/src/agent/templates.ts
+++ b/packages/cli/src/agent/templates.ts
@@ -27,6 +27,7 @@ function renderToolFiles(
             "[mcp_servers.graphtrace]",
             'command = "graphtrace"',
             'args = ["mcp"]',
+            'cwd = "."',
             "",
           ].join("\n"),
           toolId: tool,

--- a/packages/cli/test/agent-setup.test.ts
+++ b/packages/cli/test/agent-setup.test.ts
@@ -87,7 +87,7 @@ describe("agent bootstrap", () => {
     expect(plan.tools.every((tool) => tool.targets.length > 0)).toBe(true);
   });
 
-  test("renders Codex config with a GraphTrace MCP stdio entry", async () => {
+  test("renders Codex config with a GraphTrace MCP stdio entry pinned to the repo cwd", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "graphtrace-agent-"));
     const plan = await planAgentBootstrap({ workspaceRoot });
 
@@ -99,6 +99,7 @@ describe("agent bootstrap", () => {
     expect(codexConfig?.content).toContain("[mcp_servers.graphtrace]");
     expect(codexConfig?.content).toContain('command = "graphtrace"');
     expect(codexConfig?.content).toContain('args = ["mcp"]');
+    expect(codexConfig?.content).toContain('cwd = "."');
   });
 
   test("renders the Codex skill as an operating guide with concrete query sequences", async () => {

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @graphtrace/config
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+- Updated dependencies
+  - @graphtrace/shared@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/config",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/indexer/CHANGELOG.md
+++ b/packages/indexer/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @graphtrace/indexer
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+- Updated dependencies
+  - @graphtrace/config@1.5.2
+  - @graphtrace/shared@1.5.2
+  - @graphtrace/storage@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/indexer",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @graphtrace/mcp
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+- Updated dependencies
+  - @graphtrace/query-engine@1.5.2
+  - @graphtrace/shared@1.5.2
+  - @graphtrace/storage@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/mcp",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/query-engine/CHANGELOG.md
+++ b/packages/query-engine/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @graphtrace/query-engine
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+- Updated dependencies
+  - @graphtrace/indexer@1.5.2
+  - @graphtrace/shared@1.5.2
+  - @graphtrace/storage@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/query-engine/package.json
+++ b/packages/query-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/query-engine",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @graphtrace/server
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+- Updated dependencies
+  - @graphtrace/query-engine@1.5.2
+  - @graphtrace/shared@1.5.2
+  - @graphtrace/storage@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/server",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphtrace/shared
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+
 ## 1.5.1
 
 ## 1.5.0

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/shared",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/storage/CHANGELOG.md
+++ b/packages/storage/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @graphtrace/storage
 
+## 1.5.2
+
+### Patch Changes
+
+- Pin the generated Codex MCP server config to the repository working directory so GraphTrace resolves repo-local `.graphtrace` data correctly when tools launch MCP from outside the workspace root.
+- Updated dependencies
+  - @graphtrace/shared@1.5.2
+
 ## 1.5.1
 
 ### Patch Changes

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/storage",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- pin generated Codex MCP config to the repository working directory with \
- add a regression test covering the repo-pinned MCP config output
- version GraphTrace packages for the 1.5.2 release

## Test Plan
- pnpm vitest run packages/cli/test/agent-setup.test.ts packages/mcp/test/mcp.test.ts
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- pnpm test:smoke