### PR TITLE
feat: share GraphTrace MCP across workspaces

### DIFF
--- a/.changeset/mcp-multi-workspace.md
+++ b/.changeset/mcp-multi-workspace.md
@@ -1,0 +1,9 @@
+---
+"graphtrace": minor
+"@graphtrace/mcp": minor
+"@graphtrace/server": patch
+---
+
+Move GraphTrace MCP to the shared workspace registry so one MCP entry can query many indexed repos from the same GraphTrace home. Existing repo-local MCP startup still works as a legacy fallback when only a local `.graphtrace/index.db` is present, but generated Codex config no longer pins the MCP server to the repository `cwd`.
+
+Add `graphtrace agent ... --scope user` so Codex, Claude Code, and Cursor can share one machine-level GraphTrace MCP setup instead of writing bootstrap files into every repository. Project scope stays the default, `--write-mode local` remains project-only, and user-scope restore state/backups are stored under the selected GraphTrace home.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Current capabilities include:
 - route discovery for Express, Fastify, Nest, and Next App Router
 - query hints for Prisma and Drizzle patterns
 - MCP tools for search, deps, impact, flow, status, routes, packages, and reindex
-- project-local agent bootstrap for Codex, Claude Code, and Cursor
+- project or user-scoped agent bootstrap for Codex, Claude Code, and Cursor
 - agent setup lifecycle commands for setup, status, JSON status, restore, and tool-scoped restore
 - local HTTP API plus an inspection-focused web UI
 - published npm CLI package plus GitHub release notes for tagged versions
@@ -159,18 +159,22 @@ Start the MCP server:
 
 ```bash
 graphtrace mcp
+graphtrace mcp --home ~/.graphtrace-dev
 ```
 
-Bootstrap project-local AI agent config:
+Bootstrap AI agent config:
 
 ```bash
 graphtrace agent setup
 graphtrace agent setup --dry-run
 graphtrace agent setup --tool codex
+graphtrace agent setup --scope user
 graphtrace agent status
 graphtrace agent status --json
+graphtrace agent status --scope user
 graphtrace agent restore
 graphtrace agent restore --tool codex
+graphtrace agent restore --scope user
 ```
 
 Typical workflow before a risky change:
@@ -192,43 +196,66 @@ graphtrace agent setup --tool codex
 
 ## AI Agent Setup
 
-GraphTrace can generate project-local MCP and instruction files for:
+GraphTrace can generate project or user-scoped MCP and instruction files for:
 
 - Codex
 - Claude Code
 - Cursor
 
-Run:
+Run the default project-local setup:
 
 ```bash
 graphtrace agent setup
 ```
 
-This command writes only repository-local files. It does not mutate global user config outside the repo.
+Or opt into a shared user-level install:
 
-Generated files:
+```bash
+graphtrace agent setup --scope user
+```
+
+`project` remains the default scope. Use `--scope user` when the same GraphTrace MCP entry should serve many repositories from one machine-level setup.
+
+Project scope generated files:
 
 - Codex: `.codex/config.toml`, `.agents/skills/graphtrace/SKILL.md`
 - Claude Code: `.mcp.json`, `.claude/CLAUDE.md`
 - Cursor: `.cursor/mcp.json`, `.cursor/rules/graphtrace.mdc`
 
+User scope generated files:
+
+- Codex: `~/.codex/config.toml`, `~/.codex/skills/graphtrace/SKILL.md`
+- Claude Code: `~/.claude.json`, `~/.claude/CLAUDE.md`
+- Cursor: `~/.cursor/mcp.json`
+
 Useful options:
 
 - `graphtrace agent setup --dry-run` previews planned changes without writing files
 - `graphtrace agent setup --tool codex` limits setup to one supported tool
+- `graphtrace agent setup --scope user` installs shared user-level config instead of repo-local files
+- `graphtrace agent setup --scope user --home ~/.graphtrace-dev` stores user-scope restore state and backups under an alternate GraphTrace home
+- `graphtrace agent setup --write-mode local` is available only for `--scope project`
 
 Lifecycle helpers:
 
 - `graphtrace agent status` checks whether the project-local GraphTrace files are currently configured for each supported tool
+- `graphtrace agent status --scope user` checks the shared user-level integration files
 - `graphtrace agent status --json` returns the same state in structured form for automation
 - `graphtrace agent restore` rolls back the most recent `agent setup` run using the state file and backups stored under `.graphtrace`
+- `graphtrace agent restore --scope user` rolls back the most recent shared user-level setup from the GraphTrace home
 - `graphtrace agent restore --tool codex` rolls back only one supported tool and keeps the remaining setup state intact
+
+State and backups:
+
+- project scope: `<repo>/.graphtrace/agent/setup-state.json` and `<repo>/.graphtrace/backups/agent-setup/`
+- user scope: `<graphtrace-home>/.graphtrace/agent/setup-state.json` and `<graphtrace-home>/.graphtrace/backups/agent-setup/`
 
 Why this helps:
 
-- gives agents a shared local MCP entry for `graphtrace mcp`
-- pins the Codex MCP working directory so GraphTrace resolves the repo-local `.graphtrace` data even when the tool launches from outside the workspace root
+- gives agents one shared local MCP entry for `graphtrace mcp`
+- removes the repo-pinned Codex `cwd` requirement so one MCP setup can serve every workspace registered in the shared GraphTrace home
 - teaches agents when to use GraphTrace tools like `search_code`, `get_dependencies`, `get_impact_analysis`, and `get_status`
+- gives agents `list_workspaces` plus optional `workspaceId` routing when multiple repos are indexed at the same time
 - encourages narrow semantic queries before broad repository scans, which reduces wasted context and token usage
 
 Manual step:
@@ -237,7 +264,7 @@ Manual step:
 
 ### Codex Workflow
 
-If you want Codex to proactively use GraphTrace while working inside a repo, installing the npm package is not enough on its own. You also need project-local setup inside that repository.
+If you want Codex to proactively use GraphTrace while working inside a repo, installing the npm package is not enough on its own. You still need repo-local guidance files if you want GraphTrace usage instructions to live with that repository, but the MCP server itself now reads from the shared GraphTrace home instead of a repo-pinned `cwd`.
 
 Recommended sequence:
 
@@ -250,9 +277,10 @@ graphtrace agent status
 
 After setup, Codex gets:
 
-- a repo-local MCP entry that runs `graphtrace mcp`
+- a repo-local MCP entry that runs `graphtrace mcp` against the shared GraphTrace home
 - a local GraphTrace skill file that teaches when to prefer semantic graph queries over broad filesystem scans
 - a shared project convention for asking search, dependency, impact, and status questions with less prompt waste
+- a path to `list_workspaces` and `workspaceId` when more than one indexed repo could match the same question
 
 This is the difference between:
 
@@ -275,7 +303,7 @@ GraphTrace is designed to help both individual developers and teams answer the q
 - route discovery and route-to-code flow inspection when debugging request handling
 - local code search across symbols, files, packages, routes, and discovered units
 - structured repository context for AI agents through MCP instead of ad hoc prompt stuffing
-- project-local agent setup so teams can standardize AI tooling per repository
+- project or user-scoped agent setup so teams can standardize AI tooling per repository or per machine
 - internal tooling powered from one graph/query backend instead of separate ad hoc scripts
 
 ## Architecture

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,6 +42,7 @@ graphtrace search listUsers --kind symbol
 graphtrace routes
 graphtrace web --port 4310
 graphtrace mcp
+graphtrace workspace add /absolute/path/to/repo --label my-repo
 ```
 
 ## Help and version
@@ -57,7 +58,7 @@ graphtrace --version
 
 ## Agent setup
 
-Generate project-local MCP and instruction files for Codex, Claude Code, and Cursor:
+Generate project or user-scoped MCP and instruction files for Codex, Claude Code, and Cursor:
 
 ```bash
 graphtrace agent setup
@@ -69,23 +70,39 @@ Useful options:
 - `graphtrace agent setup --tool codex`
 - `graphtrace agent setup --tool claude`
 - `graphtrace agent setup --tool cursor`
+- `graphtrace agent setup --scope user`
+- `graphtrace agent setup --scope user --home ~/.graphtrace-dev`
 
 Lifecycle helpers:
 
 - `graphtrace agent status`
 - `graphtrace agent status --json`
+- `graphtrace agent status --scope user`
 - `graphtrace agent restore`
 - `graphtrace agent restore --tool codex`
+- `graphtrace agent restore --scope user`
 
-Generated files:
+Project scope generated files:
 
 - Codex: `.codex/config.toml`, `.agents/skills/graphtrace/SKILL.md`
 - Claude Code: `.mcp.json`, `.claude/CLAUDE.md`
 - Cursor: `.cursor/mcp.json`, `.cursor/rules/graphtrace.mdc`
 
+User scope generated files:
+
+- Codex: `~/.codex/config.toml`, `~/.codex/skills/graphtrace/SKILL.md`
+- Claude Code: `~/.claude.json`, `~/.claude/CLAUDE.md`
+- Cursor: `~/.cursor/mcp.json`
+
+The generated Codex MCP config no longer pins `cwd` to the repository root. One GraphTrace MCP entry can serve any workspace registered through `graphtrace workspace add`.
+
+If multiple workspaces are indexed and a request is ambiguous, ask GraphTrace for `list_workspaces` first and retry with `workspaceId`.
+
 If the target tool asks for MCP approval or trust confirmation, approve GraphTrace there after the files are generated.
 
-`graphtrace agent restore` uses the latest setup state stored in `.graphtrace/agent/setup-state.json` plus any backups under `.graphtrace/backups/agent-setup/`.
+`graphtrace agent restore` uses the latest setup state stored in `<repo>/.graphtrace/agent/setup-state.json` for project scope or `<graphtrace-home>/.graphtrace/agent/setup-state.json` for `--scope user`, plus backups under the matching `.graphtrace/backups/agent-setup/` directory.
+
+`graphtrace agent setup --write-mode local` is available only for project scope, because user-scoped files are machine-level config rather than repo artifacts.
 
 ## Notes
 

--- a/packages/cli/src/agent/bootstrap.ts
+++ b/packages/cli/src/agent/bootstrap.ts
@@ -1,10 +1,18 @@
 import { constants } from "node:fs";
 import { access } from "node:fs/promises";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
 
 export type SupportedAgentTool = "codex" | "claude" | "cursor";
+export type AgentBootstrapScope = "project" | "user";
+export type AgentBootstrapTargetKind =
+  | "instructions"
+  | "mcp_config"
+  | "rule"
+  | "skill";
 
 export interface AgentBootstrapTarget {
+  kind: AgentBootstrapTargetKind;
   path: string;
 }
 
@@ -20,10 +28,13 @@ export interface AgentBootstrapToolPlan {
 }
 
 export interface AgentBootstrapPlan {
+  scope: AgentBootstrapScope;
   tools: AgentBootstrapToolPlan[];
 }
 
 export interface PlanAgentBootstrapOptions {
+  scope?: AgentBootstrapScope;
+  userHomeDir?: string;
   workspaceRoot: string;
   tools?: SupportedAgentTool[];
   findExecutable?: (name: string) => Promise<string | null>;
@@ -39,6 +50,9 @@ export async function planAgentBootstrap(
   options: PlanAgentBootstrapOptions,
 ): Promise<AgentBootstrapPlan> {
   const findExecutable = options.findExecutable ?? findExecutableOnPath;
+  const scope = options.scope ?? "project";
+  const workspaceRoot = resolve(options.workspaceRoot);
+  const userHomeDir = resolve(options.userHomeDir ?? homedir());
 
   const selectedTools =
     options.tools ?? (Object.keys(TOOL_EXECUTABLES) as SupportedAgentTool[]);
@@ -47,11 +61,16 @@ export async function planAgentBootstrap(
     selectedTools.map(async (id) => ({
       id,
       detection: await detectTool(id, findExecutable),
-      targets: listTargets(options.workspaceRoot, id),
+      targets: listTargets({
+        scope,
+        tool: id,
+        userHomeDir,
+        workspaceRoot,
+      }),
     })),
   );
 
-  return { tools };
+  return { scope, tools };
 }
 
 async function detectTool(
@@ -74,15 +93,32 @@ async function detectTool(
   };
 }
 
-function listTargets(
+function listTargets(options: {
+  scope: AgentBootstrapScope;
+  tool: SupportedAgentTool;
+  userHomeDir: string;
+  workspaceRoot: string;
+}): AgentBootstrapTarget[] {
+  if (options.scope === "user") {
+    return listUserScopeTargets(options.userHomeDir, options.tool);
+  }
+
+  return listProjectScopeTargets(options.workspaceRoot, options.tool);
+}
+
+function listProjectScopeTargets(
   workspaceRoot: string,
   tool: SupportedAgentTool,
 ): AgentBootstrapTarget[] {
   switch (tool) {
     case "codex":
       return [
-        { path: join(workspaceRoot, ".codex", "config.toml") },
         {
+          kind: "mcp_config",
+          path: join(workspaceRoot, ".codex", "config.toml"),
+        },
+        {
+          kind: "skill",
           path: join(
             workspaceRoot,
             ".agents",
@@ -94,13 +130,62 @@ function listTargets(
       ];
     case "claude":
       return [
-        { path: join(workspaceRoot, ".mcp.json") },
-        { path: join(workspaceRoot, ".claude", "CLAUDE.md") },
+        {
+          kind: "mcp_config",
+          path: join(workspaceRoot, ".mcp.json"),
+        },
+        {
+          kind: "instructions",
+          path: join(workspaceRoot, ".claude", "CLAUDE.md"),
+        },
       ];
     case "cursor":
       return [
-        { path: join(workspaceRoot, ".cursor", "mcp.json") },
-        { path: join(workspaceRoot, ".cursor", "rules", "graphtrace.mdc") },
+        {
+          kind: "mcp_config",
+          path: join(workspaceRoot, ".cursor", "mcp.json"),
+        },
+        {
+          kind: "rule",
+          path: join(workspaceRoot, ".cursor", "rules", "graphtrace.mdc"),
+        },
+      ];
+  }
+}
+
+function listUserScopeTargets(
+  userHomeDir: string,
+  tool: SupportedAgentTool,
+): AgentBootstrapTarget[] {
+  switch (tool) {
+    case "codex":
+      return [
+        {
+          kind: "mcp_config",
+          path: join(userHomeDir, ".codex", "config.toml"),
+        },
+        {
+          kind: "skill",
+          path: join(userHomeDir, ".codex", "skills", "graphtrace", "SKILL.md"),
+        },
+      ];
+    case "claude":
+      return [
+        {
+          kind: "mcp_config",
+          path: join(userHomeDir, ".claude.json"),
+        },
+        {
+          kind: "instructions",
+          path: join(userHomeDir, ".claude", "CLAUDE.md"),
+        },
+      ];
+    case "cursor":
+      return [
+        {
+          kind: "mcp_config",
+          path: join(userHomeDir, ".cursor", "mcp.json"),
+        },
       ];
   }
 }

--- a/packages/cli/src/agent/files.ts
+++ b/packages/cli/src/agent/files.ts
@@ -8,6 +8,8 @@ const MANAGED_BLOCK_END = "<!-- graphtrace:managed:end -->";
 const AGENT_SETUP_STATE_PATH = join(".graphtrace", "agent", "setup-state.json");
 
 export interface ApplyRenderedAgentFilesOptions {
+  backupBaseDir?: string;
+  storageRoot?: string;
   workspaceRoot?: string;
   writeMode?: AgentSetupWriteMode;
 }
@@ -43,6 +45,8 @@ export async function applyRenderedAgentFiles(
   files: RenderedAgentFile[],
   options: ApplyRenderedAgentFilesOptions = {},
 ): Promise<ApplyRenderedAgentFilesResult> {
+  const storageRoot = options.storageRoot ?? options.workspaceRoot;
+  const backupBaseDir = options.backupBaseDir ?? options.workspaceRoot;
   const backups: RenderedAgentFileBackup[] = [];
   const stateEntries: AgentSetupStateEntry[] = [];
   const writtenFiles: string[] = [];
@@ -64,7 +68,8 @@ export async function applyRenderedAgentFiles(
       const backup = await maybeBackupFile(
         existing,
         file.path,
-        options.workspaceRoot,
+        storageRoot,
+        backupBaseDir,
         backupRunId,
       );
       if (backup) {
@@ -89,7 +94,8 @@ export async function applyRenderedAgentFiles(
     const backup = await maybeBackupFile(
       existing,
       file.path,
-      options.workspaceRoot,
+      storageRoot,
+      backupBaseDir,
       backupRunId,
     );
     if (backup) {
@@ -118,8 +124,8 @@ export async function applyRenderedAgentFiles(
     version: 2,
   };
 
-  if (options.workspaceRoot) {
-    await writeAgentSetupState(options.workspaceRoot, state);
+  if (storageRoot) {
+    await writeAgentSetupState(storageRoot, state);
   }
 
   return {
@@ -241,20 +247,21 @@ async function readOptionalFile(path: string): Promise<string> {
 async function maybeBackupFile(
   existingContent: string,
   targetPath: string,
-  workspaceRoot: string | undefined,
+  storageRoot: string | undefined,
+  backupBaseDir: string | undefined,
   backupRunId: string,
 ): Promise<RenderedAgentFileBackup | null> {
-  if (!existingContent || !workspaceRoot) {
+  if (!existingContent || !storageRoot || !backupBaseDir) {
     return null;
   }
 
   const backupPath = join(
-    workspaceRoot,
+    storageRoot,
     ".graphtrace",
     "backups",
     "agent-setup",
     backupRunId,
-    relative(workspaceRoot, targetPath),
+    toBackupRelativePath(backupBaseDir, targetPath),
   );
   await mkdir(dirname(backupPath), { recursive: true });
   await writeFile(backupPath, existingContent, "utf8");
@@ -366,10 +373,35 @@ function getAgentSetupStatePath(workspaceRoot: string): string {
   return join(workspaceRoot, AGENT_SETUP_STATE_PATH);
 }
 
+function toBackupRelativePath(baseDir: string, targetPath: string): string {
+  const relativePath = relative(baseDir, targetPath);
+  if (
+    relativePath &&
+    relativePath !== ".." &&
+    !relativePath.startsWith(`..${pathSeparator()}`)
+  ) {
+    return relativePath;
+  }
+
+  return join("__absolute__", ...splitAbsolutePath(targetPath));
+}
+
 function toGitIgnoreEntry(workspaceRoot: string, targetPath: string): string {
   return `/${relative(workspaceRoot, targetPath).replaceAll("\\", "/")}`;
 }
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function splitAbsolutePath(targetPath: string): string[] {
+  const normalized = resolve(targetPath)
+    .replaceAll("\\", "/")
+    .replace(/^[A-Za-z]:/, (value) => value.slice(0, -1).toLowerCase())
+    .replace(/^\/+/, "");
+  return normalized.split("/").filter(Boolean);
+}
+
+function pathSeparator(): string {
+  return process.platform === "win32" ? "\\" : "/";
 }

--- a/packages/cli/src/agent/templates.ts
+++ b/packages/cli/src/agent/templates.ts
@@ -1,4 +1,9 @@
-import type { AgentBootstrapPlan, SupportedAgentTool } from "./bootstrap";
+import type {
+  AgentBootstrapPlan,
+  AgentBootstrapTarget,
+  AgentBootstrapTargetKind,
+  SupportedAgentTool,
+} from "./bootstrap";
 
 export interface RenderedAgentFile {
   path: string;
@@ -16,86 +21,116 @@ export function renderAgentBootstrapFiles(
 
 function renderToolFiles(
   tool: SupportedAgentTool,
-  targets: Array<{ path: string }>,
+  targets: AgentBootstrapTarget[],
 ): RenderedAgentFile[] {
+  const configPath = findTargetPath(targets, "mcp_config");
+
   switch (tool) {
-    case "codex":
-      return [
-        {
-          path: targets[0].path,
-          content: [
-            "[mcp_servers.graphtrace]",
-            'command = "graphtrace"',
-            'args = ["mcp"]',
-            'cwd = "."',
-            "",
-          ].join("\n"),
-          toolId: tool,
-          strategy: "replace",
-        },
-        {
-          path: targets[1].path,
-          content: renderCodexSkill(),
-          toolId: tool,
-          strategy: "replace",
-        },
-      ];
-    case "claude": {
-      const managedContent = renderSharedGuidance("Claude Code");
-      return [
-        {
-          path: targets[0].path,
-          content: JSON.stringify(
-            {
-              mcpServers: {
-                graphtrace: {
-                  command: "graphtrace",
-                  args: ["mcp"],
-                },
-              },
-            },
-            null,
-            2,
-          ).concat("\n"),
-          toolId: tool,
-          strategy: "replace",
-        },
-        {
-          path: targets[1].path,
-          content: wrapManagedMarkdownBlock(managedContent),
-          managedContent,
-          toolId: tool,
-          strategy: "managed_markdown",
-        },
-      ];
+    case "codex": {
+      const skillPath = findTargetPath(targets, "skill");
+      const skillFile: RenderedAgentFile | null = skillPath
+        ? {
+            path: skillPath,
+            content: renderCodexSkill(),
+            toolId: tool,
+            strategy: "replace",
+          }
+        : null;
+      return [renderCodexConfigFile(configPath), skillFile].filter(
+        isRenderedAgentFile,
+      );
     }
-    case "cursor":
-      return [
-        {
-          path: targets[0].path,
-          content: JSON.stringify(
-            {
-              mcpServers: {
-                graphtrace: {
-                  command: "graphtrace",
-                  args: ["mcp"],
-                },
-              },
-            },
-            null,
-            2,
-          ).concat("\n"),
-          toolId: tool,
-          strategy: "replace",
-        },
-        {
-          path: targets[1].path,
-          content: renderCursorRule(),
-          toolId: tool,
-          strategy: "replace",
-        },
-      ];
+    case "claude": {
+      const instructionsPath = findTargetPath(targets, "instructions");
+      const managedContent = renderSharedGuidance("Claude Code");
+      const instructionsFile: RenderedAgentFile | null = instructionsPath
+        ? {
+            path: instructionsPath,
+            content: wrapManagedMarkdownBlock(managedContent),
+            managedContent,
+            toolId: tool,
+            strategy: "managed_markdown",
+          }
+        : null;
+      return [renderMcpConfigFile(tool, configPath), instructionsFile].filter(
+        isRenderedAgentFile,
+      );
+    }
+    case "cursor": {
+      const rulePath = findTargetPath(targets, "rule");
+      const ruleFile: RenderedAgentFile | null = rulePath
+        ? {
+            path: rulePath,
+            content: renderCursorRule(),
+            toolId: tool,
+            strategy: "replace",
+          }
+        : null;
+      return [renderMcpConfigFile(tool, configPath), ruleFile].filter(
+        isRenderedAgentFile,
+      );
+    }
   }
+}
+
+function renderMcpConfigFile(
+  toolId: SupportedAgentTool,
+  path: string | undefined,
+): RenderedAgentFile | null {
+  if (!path) {
+    return null;
+  }
+
+  return {
+    path,
+    content: JSON.stringify(
+      {
+        mcpServers: {
+          graphtrace: {
+            command: "graphtrace",
+            args: ["mcp"],
+          },
+        },
+      },
+      null,
+      2,
+    ).concat("\n"),
+    toolId,
+    strategy: "replace",
+  };
+}
+
+function renderCodexConfigFile(
+  path: string | undefined,
+): RenderedAgentFile | null {
+  if (!path) {
+    return null;
+  }
+
+  return {
+    path,
+    content: [
+      "[mcp_servers.graphtrace]",
+      'command = "graphtrace"',
+      'args = ["mcp"]',
+      "",
+    ].join("\n"),
+    toolId: "codex",
+    strategy: "replace",
+  };
+}
+
+function findTargetPath(
+  targets: AgentBootstrapTarget[],
+  kind: AgentBootstrapTargetKind,
+): string | undefined {
+  return targets.find((target) => target.kind === kind)?.path;
+}
+
+function isRenderedAgentFile(
+  value: RenderedAgentFile | null,
+): value is RenderedAgentFile {
+  return value !== null;
 }
 
 export function wrapManagedMarkdownBlock(content: string): string {
@@ -115,18 +150,21 @@ function renderCodexSkill(): string {
     "---",
     "",
     "Use GraphTrace from Codex when the task needs repository structure, semantic code context, or a fast first pass on dependencies before broad filesystem scans.",
+    "One GraphTrace MCP entry can serve every workspace registered in the shared GraphTrace home.",
     "",
     "## Decision tree",
     "- If you are unsure whether the graph is fresh, start with `get_status` -> `run_index` and only re-index when the last run is missing, stale, or the workspace changed significantly.",
     "- If you need to change a route or trace a request path, use `get_routes` -> `search_code` -> `get_data_flow` before opening files broadly.",
     "- If you need blast radius before editing a file, use `get_impact_analysis` -> `get_dependencies` and inspect both callers and downstream dependencies before patching.",
     "- If you need to locate a symbol or package quickly, use `search_code` -> `get_symbol_context` for symbols and `list_packages` -> `get_package_overview` for package-level orientation.",
+    "- If multiple workspaces are registered and the tool call is ambiguous, use `list_workspaces` first and pass `workspaceId` on the next call.",
     "",
     "## Common sequences",
     "- Change a route: start with `get_routes` to confirm the route, use `search_code` to find the owning file or handler, then run `get_data_flow` to understand request-to-query flow before editing.",
     "- Blast radius before editing a file: run `get_impact_analysis` first for the broad impact set, then `get_dependencies` with a narrow depth to verify important inbound or outbound edges.",
     "- Locate a symbol or package quickly: use `search_code` for the first hit, `get_symbol_context` when multiple matches need disambiguation, and `list_packages` or `get_package_overview` when the question is architectural rather than file-local.",
     "- Check whether the graph is stale: call `get_status`; if the index is missing or clearly behind recent workspace changes, run `run_index` before trusting dependency or flow results.",
+    "- Resolve workspace ambiguity: call `list_workspaces`, pick the matching `workspaceId`, then retry `search_code`, `get_routes`, `get_dependencies`, or the symbol tools with that `workspaceId`.",
     "",
     "## Fallback when GraphTrace is sparse",
     "- If GraphTrace returns partial or empty results, verify freshness with `get_status` and re-run `run_index` before assuming the code truly has no edges.",
@@ -160,6 +198,7 @@ function renderSharedGuidance(toolName: string): string {
     "- Prefer narrow queries first before broad scans or large dumps.",
     "- Use GraphTrace before filesystem-wide grep when you need semantic code context or dependency insight.",
     "- Call `get_status` before `run_index` when you suspect stale graph data.",
+    "- Call `list_workspaces` and pass `workspaceId` when multiple registered workspaces could match the same question.",
     "- Use `search_code` and `get_symbol_context` for targeted symbol lookups.",
     "- Use `get_dependencies` for dependency tracing.",
     "- Use `get_impact_analysis` for blast-radius checks before edits.",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,7 +13,11 @@ import type {
 } from "@graphtrace/shared";
 import type { WorkspaceRecord } from "@graphtrace/storage";
 
-import { type SupportedAgentTool, planAgentBootstrap } from "./agent/bootstrap";
+import {
+  type AgentBootstrapScope,
+  type SupportedAgentTool,
+  planAgentBootstrap,
+} from "./agent/bootstrap";
 import {
   type AgentSetupWriteMode,
   applyRenderedAgentFiles,
@@ -358,19 +362,24 @@ const CLI_HELP_TREE: CliHelpCommand = {
     {
       name: "agent",
       heading: "graphtrace agent",
-      summary: "Generate and manage project-local agent integration files.",
+      summary:
+        "Generate and manage project or user-scoped agent integration files.",
       usage: "graphtrace agent <subcommand> [options]",
       commands: [
         {
           name: "setup",
           heading: "graphtrace agent setup",
-          summary: "Generate project-local MCP and instruction files.",
+          summary: "Generate project or user-scoped MCP and instruction files.",
           usage:
-            "graphtrace agent setup [--tool <codex|claude|cursor>] [--dry-run] [--write-mode <tracked|local>]",
+            "graphtrace agent setup [--tool <codex|claude|cursor>] [--scope <project|user>] [--dry-run] [--write-mode <tracked|local>] [--home <path>]",
           options: [
             {
               flags: "--tool <tool>",
               description: "Limit setup to one supported tool.",
+            },
+            {
+              flags: "--scope <scope>",
+              description: "Choose project-local or user-scoped installation.",
             },
             {
               flags: "--dry-run",
@@ -381,48 +390,76 @@ const CLI_HELP_TREE: CliHelpCommand = {
               description:
                 "Write generated files as tracked or local-only artifacts.",
             },
+            {
+              flags: "--home <path>",
+              description:
+                "Override the GraphTrace home used for user-scope backups and restore state.",
+            },
           ],
           examples: [
             "graphtrace agent setup",
             "graphtrace agent setup --dry-run",
             "graphtrace agent setup --tool codex",
+            "graphtrace agent setup --scope user",
           ],
         },
         {
           name: "status",
           heading: "graphtrace agent status",
-          summary: "Inspect configured GraphTrace agent files.",
+          summary:
+            "Inspect configured GraphTrace agent files for a chosen scope.",
           usage:
-            "graphtrace agent status [--tool <codex|claude|cursor>] [--json]",
+            "graphtrace agent status [--tool <codex|claude|cursor>] [--scope <project|user>] [--json] [--home <path>]",
           options: [
             {
               flags: "--tool <tool>",
               description: "Limit inspection to one supported tool.",
             },
             {
+              flags: "--scope <scope>",
+              description: "Inspect project-local or user-scoped integration.",
+            },
+            {
               flags: "--json",
               description: "Print status as structured JSON.",
+            },
+            {
+              flags: "--home <path>",
+              description:
+                "Override the GraphTrace home used for user-scope restore state.",
             },
           ],
           examples: [
             "graphtrace agent status",
             "graphtrace agent status --json",
+            "graphtrace agent status --scope user",
           ],
         },
         {
           name: "restore",
           heading: "graphtrace agent restore",
           summary: "Restore the most recent agent setup state.",
-          usage: "graphtrace agent restore [--tool <codex|claude|cursor>]",
+          usage:
+            "graphtrace agent restore [--tool <codex|claude|cursor>] [--scope <project|user>] [--home <path>]",
           options: [
             {
               flags: "--tool <tool>",
               description: "Restore only one supported tool.",
             },
+            {
+              flags: "--scope <scope>",
+              description: "Restore project-local or user-scoped integration.",
+            },
+            {
+              flags: "--home <path>",
+              description:
+                "Override the GraphTrace home used for user-scope restore state.",
+            },
           ],
           examples: [
             "graphtrace agent restore",
             "graphtrace agent restore --tool codex",
+            "graphtrace agent restore --scope user",
           ],
         },
       ],
@@ -437,9 +474,18 @@ const CLI_HELP_TREE: CliHelpCommand = {
       name: "mcp",
       heading: "graphtrace mcp",
       summary: "Start the GraphTrace MCP server on stdio.",
-      usage: "graphtrace mcp",
-      examples: ["graphtrace mcp"],
-      notes: ["This command stays alive and serves MCP requests over stdio."],
+      usage: "graphtrace mcp [--home <path>]",
+      options: [
+        {
+          flags: "--home <path>",
+          description: "Override the shared GraphTrace home directory.",
+        },
+      ],
+      examples: ["graphtrace mcp", "graphtrace mcp --home ~/.graphtrace-dev"],
+      notes: [
+        "This command stays alive and serves MCP requests over stdio.",
+        "When --home is omitted, GraphTrace uses the current user's home directory.",
+      ],
     },
   ],
 };
@@ -540,12 +586,26 @@ export async function runCli(
     }
     case "agent": {
       const [subcommand, ...agentArgs] = args;
+      const scope = readAgentScopeOption(agentArgs, "--scope") ?? "project";
       const selectedTool = readAgentToolOption(agentArgs, "--tool");
       const writeMode = readAgentWriteModeOption(agentArgs, "--write-mode");
+      const graphTraceHome = readHomeOption(agentArgs);
+      const userHomeDir = homedir();
 
       switch (subcommand) {
         case "setup": {
+          if (scope === "user" && writeMode === "local") {
+            return {
+              exitCode: 1,
+              stdout: "",
+              stderr:
+                "write-mode local is only supported for project-scoped agent setup",
+            };
+          }
+
           const plan = await planAgentBootstrap({
+            scope,
+            userHomeDir,
             workspaceRoot: cwd,
             tools: selectedTool ? [selectedTool] : undefined,
           });
@@ -559,7 +619,9 @@ export async function runCli(
                 writtenFiles: [],
               }
             : await applyRenderedAgentFiles(renderedFiles, {
-                workspaceRoot: cwd,
+                backupBaseDir: scope === "user" ? userHomeDir : cwd,
+                storageRoot: scope === "user" ? graphTraceHome : cwd,
+                workspaceRoot: scope === "project" ? cwd : undefined,
                 writeMode,
               });
 
@@ -578,6 +640,8 @@ export async function runCli(
         }
         case "status": {
           const plan = await planAgentBootstrap({
+            scope,
+            userHomeDir,
             workspaceRoot: cwd,
             tools: selectedTool ? [selectedTool] : undefined,
           });
@@ -591,7 +655,9 @@ export async function runCli(
           };
         }
         case "restore": {
-          const state = await loadAgentSetupState(cwd);
+          const state = await loadAgentSetupState(
+            scope === "user" ? graphTraceHome : cwd,
+          );
           if (!state) {
             return {
               exitCode: 1,
@@ -601,7 +667,7 @@ export async function runCli(
           }
 
           const restoredFiles = await restoreAgentSetupState(
-            cwd,
+            scope === "user" ? graphTraceHome : cwd,
             state,
             selectedTool,
           );
@@ -833,7 +899,10 @@ export async function runCli(
     }
     case "mcp": {
       const { createGraphTraceMcpServer } = await loadMcpModule();
-      await createGraphTraceMcpServer({ workspaceRoot: cwd });
+      await createGraphTraceMcpServer({
+        workspaceRoot: cwd,
+        homeDir: readHomeOption(args),
+      });
       return {
         exitCode: 0,
         stdout: "",
@@ -1313,6 +1382,18 @@ function readAgentToolOption(
 ): SupportedAgentTool | undefined {
   const raw = readOption(argv, name);
   if (raw === "codex" || raw === "claude" || raw === "cursor") {
+    return raw;
+  }
+
+  return undefined;
+}
+
+function readAgentScopeOption(
+  argv: string[],
+  name: string,
+): AgentBootstrapScope | undefined {
+  const raw = readOption(argv, name);
+  if (raw === "project" || raw === "user") {
     return raw;
   }
 

--- a/packages/cli/test/agent-setup.test.ts
+++ b/packages/cli/test/agent-setup.test.ts
@@ -70,6 +70,64 @@ describe("agent bootstrap", () => {
     );
   });
 
+  test("plans user-scoped targets under the current user home", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "graphtrace-agent-"));
+    const userHomeDir = await mkdtemp(join(tmpdir(), "graphtrace-agent-home-"));
+
+    const plan = await planAgentBootstrap({
+      scope: "user",
+      userHomeDir,
+      workspaceRoot,
+    });
+
+    expect(plan.tools.map((tool) => tool.id)).toEqual([
+      "codex",
+      "claude",
+      "cursor",
+    ]);
+
+    expect(plan.tools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "codex",
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              path: join(userHomeDir, ".codex", "config.toml"),
+            }),
+            expect.objectContaining({
+              path: join(
+                userHomeDir,
+                ".codex",
+                "skills",
+                "graphtrace",
+                "SKILL.md",
+              ),
+            }),
+          ]),
+        }),
+        expect.objectContaining({
+          id: "claude",
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              path: join(userHomeDir, ".claude.json"),
+            }),
+            expect.objectContaining({
+              path: join(userHomeDir, ".claude", "CLAUDE.md"),
+            }),
+          ]),
+        }),
+        expect.objectContaining({
+          id: "cursor",
+          targets: expect.arrayContaining([
+            expect.objectContaining({
+              path: join(userHomeDir, ".cursor", "mcp.json"),
+            }),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   test("keeps planning files even when tool executables are not installed", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "graphtrace-agent-"));
 
@@ -87,7 +145,7 @@ describe("agent bootstrap", () => {
     expect(plan.tools.every((tool) => tool.targets.length > 0)).toBe(true);
   });
 
-  test("renders Codex config with a GraphTrace MCP stdio entry pinned to the repo cwd", async () => {
+  test("renders Codex config with a shared GraphTrace MCP stdio entry instead of a repo-pinned cwd", async () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), "graphtrace-agent-"));
     const plan = await planAgentBootstrap({ workspaceRoot });
 
@@ -99,7 +157,7 @@ describe("agent bootstrap", () => {
     expect(codexConfig?.content).toContain("[mcp_servers.graphtrace]");
     expect(codexConfig?.content).toContain('command = "graphtrace"');
     expect(codexConfig?.content).toContain('args = ["mcp"]');
-    expect(codexConfig?.content).toContain('cwd = "."');
+    expect(codexConfig?.content).not.toContain('cwd = "."');
   });
 
   test("renders the Codex skill as an operating guide with concrete query sequences", async () => {
@@ -134,6 +192,8 @@ describe("agent bootstrap", () => {
     expect(codexSkill?.content).toContain(
       "Re-run `run_index` after significant workspace changes",
     );
+    expect(codexSkill?.content).toContain("`list_workspaces`");
+    expect(codexSkill?.content).toContain("`workspaceId`");
   });
 
   test("renders Claude config and managed CLAUDE.md guidance", async () => {
@@ -174,6 +234,41 @@ describe("agent bootstrap", () => {
     expect(mcpConfig?.content).toContain('"graphtrace"');
     expect(cursorRule?.content).toContain("description: GraphTrace usage");
     expect(cursorRule?.content).toContain("search_code");
+  });
+
+  test("renders user-scoped files without requiring a Cursor project rule", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "graphtrace-agent-"));
+    const userHomeDir = await mkdtemp(join(tmpdir(), "graphtrace-agent-home-"));
+    const plan = await planAgentBootstrap({
+      scope: "user",
+      userHomeDir,
+      workspaceRoot,
+    });
+
+    const renderedFiles = renderAgentBootstrapFiles(plan);
+
+    expect(renderedFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: join(userHomeDir, ".codex", "config.toml"),
+        }),
+        expect.objectContaining({
+          path: join(userHomeDir, ".codex", "skills", "graphtrace", "SKILL.md"),
+        }),
+        expect.objectContaining({
+          path: join(userHomeDir, ".claude.json"),
+        }),
+        expect.objectContaining({
+          path: join(userHomeDir, ".claude", "CLAUDE.md"),
+        }),
+        expect.objectContaining({
+          path: join(userHomeDir, ".cursor", "mcp.json"),
+        }),
+      ]),
+    );
+    expect(
+      renderedFiles.some((file) => file.path.endsWith("graphtrace.mdc")),
+    ).toBe(false);
   });
 
   test("re-running file reconciliation does not duplicate GraphTrace entries", async () => {
@@ -283,6 +378,7 @@ describe("agent bootstrap", () => {
       expect(file.content).toContain("get_routes");
       expect(file.content).toContain("get_status");
       expect(file.content).toContain("run_index");
+      expect(file.content).toContain("list_workspaces");
     }
   });
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -56,6 +56,24 @@ function runCliProcess(
   });
 }
 
+async function withUserHome<T>(
+  userHome: string,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const previousHome = process.env.HOME;
+  process.env.HOME = userHome;
+
+  try {
+    return await callback();
+  } finally {
+    if (previousHome === undefined) {
+      process.env.HOME = undefined;
+    } else {
+      process.env.HOME = previousHome;
+    }
+  }
+}
+
 describe("cli", () => {
   const fixtureRoot = join(
     process.cwd(),
@@ -250,6 +268,41 @@ describe("cli", () => {
     ).resolves.toBeUndefined();
   });
 
+  test("agent setup --scope user writes shared user-level files instead of repo-local files", async () => {
+    const workspaceRoot = await mkdtemp(
+      join(tmpdir(), "graphtrace-cli-agent-user-"),
+    );
+    const userHome = await mkdtemp(join(tmpdir(), "graphtrace-cli-home-"));
+
+    const result = await withUserHome(userHome, () =>
+      runCli(["agent", "setup", "--scope", "user"], { cwd: workspaceRoot }),
+    );
+
+    expect(result.exitCode).toBe(0);
+    await expect(
+      access(join(userHome, ".codex", "config.toml")),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(userHome, ".codex", "skills", "graphtrace", "SKILL.md")),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(userHome, ".claude.json")),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(userHome, ".claude", "CLAUDE.md")),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(userHome, ".cursor", "mcp.json")),
+    ).resolves.toBeUndefined();
+    await expect(
+      access(join(workspaceRoot, ".codex", "config.toml")),
+    ).rejects.toThrow();
+    await expect(access(join(workspaceRoot, ".mcp.json"))).rejects.toThrow();
+    await expect(
+      access(join(workspaceRoot, ".cursor", "mcp.json")),
+    ).rejects.toThrow();
+  });
+
   test("agent setup --dry-run previews changes without writing files", async () => {
     const workspaceRoot = await mkdtemp(
       join(tmpdir(), "graphtrace-cli-agent-"),
@@ -288,6 +341,22 @@ describe("cli", () => {
     await expect(
       access(join(workspaceRoot, ".cursor", "mcp.json")),
     ).rejects.toThrow();
+  });
+
+  test("agent setup --scope user rejects local write mode", async () => {
+    const workspaceRoot = await mkdtemp(
+      join(tmpdir(), "graphtrace-cli-agent-user-local-"),
+    );
+    const userHome = await mkdtemp(join(tmpdir(), "graphtrace-cli-home-"));
+
+    const result = await withUserHome(userHome, () =>
+      runCli(["agent", "setup", "--scope", "user", "--write-mode", "local"], {
+        cwd: workspaceRoot,
+      }),
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("write-mode local is only supported");
   });
 
   test("agent setup --write-mode local keeps generated files out of git status", async () => {
@@ -440,6 +509,28 @@ describe("cli", () => {
     expect(result.stdout).toContain("tool:cursor:configured");
   });
 
+  test("agent status --scope user reports configured user-level integrations", async () => {
+    const workspaceRoot = await mkdtemp(
+      join(tmpdir(), "graphtrace-cli-agent-status-user-"),
+    );
+    const userHome = await mkdtemp(join(tmpdir(), "graphtrace-cli-home-"));
+
+    const result = await withUserHome(userHome, async () => {
+      await runCli(["agent", "setup", "--scope", "user"], {
+        cwd: workspaceRoot,
+      });
+      return runCli(["agent", "status", "--scope", "user"], {
+        cwd: workspaceRoot,
+      });
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("agent status");
+    expect(result.stdout).toContain("tool:codex:configured");
+    expect(result.stdout).toContain("tool:claude:configured");
+    expect(result.stdout).toContain("tool:cursor:configured");
+  });
+
   test("agent status --json returns structured tool status", async () => {
     const workspaceRoot = await mkdtemp(
       join(tmpdir(), "graphtrace-cli-agent-status-json-"),
@@ -543,6 +634,38 @@ describe("cli", () => {
     await expect(
       access(join(workspaceRoot, ".cursor", "mcp.json")),
     ).resolves.toBeUndefined();
+  });
+
+  test("agent restore --scope user removes shared user-level files and restores prior content", async () => {
+    const workspaceRoot = await mkdtemp(
+      join(tmpdir(), "graphtrace-cli-agent-restore-user-"),
+    );
+    const userHome = await mkdtemp(join(tmpdir(), "graphtrace-cli-home-"));
+    const claudePath = join(userHome, ".claude", "CLAUDE.md");
+
+    await mkdir(join(userHome, ".claude"), { recursive: true });
+    await writeFile(claudePath, "# existing global claude memory\n", "utf8");
+
+    const restoreResult = await withUserHome(userHome, async () => {
+      await runCli(["agent", "setup", "--scope", "user"], {
+        cwd: workspaceRoot,
+      });
+      return runCli(["agent", "restore", "--scope", "user"], {
+        cwd: workspaceRoot,
+      });
+    });
+
+    expect(restoreResult.exitCode).toBe(0);
+    expect(await readFile(claudePath, "utf8")).toBe(
+      "# existing global claude memory\n",
+    );
+    await expect(
+      access(join(userHome, ".codex", "config.toml")),
+    ).rejects.toThrow();
+    await expect(access(join(userHome, ".claude.json"))).rejects.toThrow();
+    await expect(
+      access(join(userHome, ".cursor", "mcp.json")),
+    ).rejects.toThrow();
   });
 
   test("doctor --units reports discovered units for non-standard layouts", async () => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@graphtrace/query-engine": "workspace:*",
+    "@graphtrace/server": "workspace:*",
     "@graphtrace/shared": "workspace:*",
     "@graphtrace/storage": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,3 +1,7 @@
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
@@ -7,7 +11,9 @@ import {
   runWorkspaceIndex,
   withWorkspaceQueryEngine,
 } from "@graphtrace/query-engine";
-import type { SymbolLocator } from "@graphtrace/shared";
+import { createGraphTraceDaemon } from "@graphtrace/server";
+import { GRAPHTRACE_DB_PATH, type SymbolLocator } from "@graphtrace/shared";
+import type { WorkspaceRecord } from "@graphtrace/storage";
 
 function asToolResult(payload: unknown) {
   return {
@@ -21,17 +27,112 @@ function asToolResult(payload: unknown) {
   };
 }
 
-export async function createGraphTraceMcpServer(options: {
+interface GraphTraceMcpServerOptions {
+  homeDir?: string;
+  workspaceRoot?: string;
+}
+
+interface WorkspaceResolutionHint {
+  workspaceId?: string;
+  target?: string;
+  filePath?: string;
+  symbolId?: string;
+}
+
+interface ResolvedWorkspaceContext {
+  workspaceId?: string;
   workspaceRoot: string;
-}) {
+  withQueryEngine<T>(
+    action: (engine: ReturnType<typeof createQueryEngine>) => T,
+  ): T;
+  status(): unknown;
+  runIndex(mode: "full" | "incremental"): Promise<unknown>;
+}
+
+export async function createGraphTraceMcpServer(
+  options: GraphTraceMcpServerOptions = {},
+) {
+  const homeDir = options.homeDir ?? homedir();
+  const daemon = createGraphTraceDaemon({ homeDir });
   const server = new McpServer({
     name: "graphtrace",
     version: "1.0.0",
   });
-  const withQueryEngine = <T>(
-    action: (engine: ReturnType<typeof createQueryEngine>) => T,
-  ) =>
-    withWorkspaceQueryEngine(options.workspaceRoot, (engine) => action(engine));
+
+  const withResolvedWorkspace = <T>(
+    hint: WorkspaceResolutionHint,
+    action: (context: ResolvedWorkspaceContext) => T,
+  ) => action(resolveWorkspaceContext(hint));
+
+  server.registerTool(
+    "list_workspaces",
+    {
+      description: "List GraphTrace workspaces available from the shared home.",
+      inputSchema: {},
+    },
+    async () =>
+      asToolResult({
+        items: daemon.listWorkspaceSummaries(),
+      }),
+  );
+
+  server.registerTool(
+    "add_workspace",
+    {
+      description: "Register and index a new workspace in the shared home.",
+      inputSchema: {
+        rootPath: z.string(),
+        label: z.string().optional(),
+      },
+    },
+    async ({ rootPath, label }) => {
+      const workspace = await daemon.addWorkspace(resolve(rootPath), { label });
+      return asToolResult({
+        workspace,
+        status: daemon.status(workspace.id),
+      });
+    },
+  );
+
+  server.registerTool(
+    "reindex_workspace",
+    {
+      description: "Reindex an existing shared GraphTrace workspace.",
+      inputSchema: {
+        workspaceId: z.string(),
+      },
+    },
+    async ({ workspaceId }) => {
+      const workspace = await daemon.reindexWorkspace(workspaceId);
+      return asToolResult({
+        workspace,
+        status: daemon.status(workspace.id),
+      });
+    },
+  );
+
+  server.registerTool(
+    "remove_workspace",
+    {
+      description: "Remove a workspace from the shared GraphTrace home.",
+      inputSchema: {
+        workspaceId: z.string(),
+      },
+    },
+    async ({ workspaceId }) => {
+      const workspace = daemon.getWorkspace(workspaceId);
+      if (!workspace) {
+        throw new Error(`Unknown workspace: ${workspaceId}`);
+      }
+
+      daemon.removeWorkspace(workspaceId);
+      return asToolResult({
+        removed: true,
+        workspaceId,
+        label: workspace.label,
+      });
+    },
+  );
 
   server.registerTool(
     "graphtrace_search_symbols",
@@ -40,10 +141,15 @@ export async function createGraphTraceMcpServer(options: {
         "Search symbol definitions by name and return a zero-hop graph envelope.",
       inputSchema: {
         query: z.string(),
+        workspaceId: z.string().optional(),
       },
     },
-    async ({ query }) =>
-      asToolResult(withQueryEngine((engine) => engine.searchSymbols(query))),
+    async ({ query, workspaceId }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId }, (context) =>
+          context.withQueryEngine((engine) => engine.searchSymbols(query)),
+        ),
+      ),
   );
 
   server.registerTool(
@@ -52,6 +158,7 @@ export async function createGraphTraceMcpServer(options: {
       description:
         "Resolve a symbol by id, file plus name, or file plus position.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         symbolId: z.string().optional(),
         filePath: z.string().optional(),
         symbolName: z.string().optional(),
@@ -59,9 +166,19 @@ export async function createGraphTraceMcpServer(options: {
         column: z.number().int().positive().optional(),
       },
     },
-    async (locator) =>
+    async ({ workspaceId, ...locator }) =>
       asToolResult(
-        withQueryEngine((engine) => engine.getSymbol(toSymbolLocator(locator))),
+        withResolvedWorkspace(
+          {
+            workspaceId,
+            filePath: locator.filePath,
+            symbolId: locator.symbolId,
+          },
+          (context) =>
+            context.withQueryEngine((engine) =>
+              engine.getSymbol(toSymbolLocator(locator)),
+            ),
+        ),
       ),
   );
 
@@ -71,6 +188,7 @@ export async function createGraphTraceMcpServer(options: {
       description:
         "Get upstream callers, downstream callees, and sinks for a symbol.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         symbolId: z.string().optional(),
         filePath: z.string().optional(),
         symbolName: z.string().optional(),
@@ -80,13 +198,21 @@ export async function createGraphTraceMcpServer(options: {
         maxEdges: z.number().int().positive().optional(),
       },
     },
-    async ({ maxNodes, maxEdges, ...locator }) =>
+    async ({ workspaceId, maxNodes, maxEdges, ...locator }) =>
       asToolResult(
-        withQueryEngine((engine) =>
-          engine.executionContextFromSymbol(toSymbolLocator(locator), {
-            maxNodes,
-            maxEdges,
-          }),
+        withResolvedWorkspace(
+          {
+            workspaceId,
+            filePath: locator.filePath,
+            symbolId: locator.symbolId,
+          },
+          (context) =>
+            context.withQueryEngine((engine) =>
+              engine.executionContextFromSymbol(toSymbolLocator(locator), {
+                maxNodes,
+                maxEdges,
+              }),
+            ),
         ),
       ),
   );
@@ -97,6 +223,7 @@ export async function createGraphTraceMcpServer(options: {
       description:
         "Get an impact-oriented symbol graph with truncation metadata.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         symbolId: z.string().optional(),
         filePath: z.string().optional(),
         symbolName: z.string().optional(),
@@ -106,13 +233,21 @@ export async function createGraphTraceMcpServer(options: {
         maxEdges: z.number().int().positive().optional(),
       },
     },
-    async ({ maxNodes, maxEdges, ...locator }) =>
+    async ({ workspaceId, maxNodes, maxEdges, ...locator }) =>
       asToolResult(
-        withQueryEngine((engine) =>
-          engine.impactFromSymbol(toSymbolLocator(locator), {
-            maxNodes,
-            maxEdges,
-          }),
+        withResolvedWorkspace(
+          {
+            workspaceId,
+            filePath: locator.filePath,
+            symbolId: locator.symbolId,
+          },
+          (context) =>
+            context.withQueryEngine((engine) =>
+              engine.impactFromSymbol(toSymbolLocator(locator), {
+                maxNodes,
+                maxEdges,
+              }),
+            ),
         ),
       ),
   );
@@ -122,11 +257,16 @@ export async function createGraphTraceMcpServer(options: {
     {
       description: "Explain provenance and confidence for a symbol graph edge.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         edgeId: z.string(),
       },
     },
-    async ({ edgeId }) =>
-      asToolResult(withQueryEngine((engine) => engine.explainEdge(edgeId))),
+    async ({ workspaceId, edgeId }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId }, (context) =>
+          context.withQueryEngine((engine) => engine.explainEdge(edgeId)),
+        ),
+      ),
   );
 
   server.registerTool(
@@ -135,10 +275,15 @@ export async function createGraphTraceMcpServer(options: {
       description: "Search code, symbols, routes, files, and packages.",
       inputSchema: {
         query: z.string(),
+        workspaceId: z.string().optional(),
       },
     },
-    async ({ query }) =>
-      asToolResult(withQueryEngine((engine) => engine.search(query))),
+    async ({ query, workspaceId }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId }, (context) =>
+          context.withQueryEngine((engine) => engine.search(query)),
+        ),
+      ),
   );
 
   server.registerTool(
@@ -147,10 +292,15 @@ export async function createGraphTraceMcpServer(options: {
       description: "Get symbol-oriented context using GraphTrace search.",
       inputSchema: {
         query: z.string(),
+        workspaceId: z.string().optional(),
       },
     },
-    async ({ query }) =>
-      asToolResult(withQueryEngine((engine) => engine.getSymbolContext(query))),
+    async ({ query, workspaceId }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId }, (context) =>
+          context.withQueryEngine((engine) => engine.getSymbolContext(query)),
+        ),
+      ),
   );
 
   server.registerTool(
@@ -158,15 +308,18 @@ export async function createGraphTraceMcpServer(options: {
     {
       description: "Get dependencies for a file path.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         target: z.string(),
         direction: z.enum(["in", "out", "both"]).default("both"),
         depth: z.number().int().positive().default(1),
       },
     },
-    async ({ target, direction, depth }) =>
+    async ({ workspaceId, target, direction, depth }) =>
       asToolResult(
-        withQueryEngine((engine) =>
-          engine.dependencies(target, direction, depth),
+        withResolvedWorkspace({ workspaceId, target }, (context) =>
+          context.withQueryEngine((engine) =>
+            engine.dependencies(target, direction, depth),
+          ),
         ),
       ),
   );
@@ -176,12 +329,17 @@ export async function createGraphTraceMcpServer(options: {
     {
       description: "Get static impact analysis for a file path.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         target: z.string(),
         depth: z.number().int().positive().default(6),
       },
     },
-    async ({ target, depth }) =>
-      asToolResult(withQueryEngine((engine) => engine.impact(target, depth))),
+    async ({ workspaceId, target, depth }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId, target }, (context) =>
+          context.withQueryEngine((engine) => engine.impact(target, depth)),
+        ),
+      ),
   );
 
   server.registerTool(
@@ -189,78 +347,251 @@ export async function createGraphTraceMcpServer(options: {
     {
       description: "Get route-to-query flow using GraphTrace heuristics.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         target: z.string(),
         depth: z.number().int().positive().default(6),
       },
     },
-    async ({ target, depth }) =>
-      asToolResult(withQueryEngine((engine) => engine.flow(target, depth))),
+    async ({ workspaceId, target, depth }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId, target }, (context) =>
+          context.withQueryEngine((engine) => engine.flow(target, depth)),
+        ),
+      ),
   );
 
   server.registerTool(
     "get_routes",
     {
-      description: "List routes discovered in the indexed workspace.",
-      inputSchema: {},
+      description: "List routes discovered in the selected workspace.",
+      inputSchema: {
+        workspaceId: z.string().optional(),
+      },
     },
-    async () => asToolResult(withQueryEngine((engine) => engine.routes())),
+    async ({ workspaceId }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId }, (context) =>
+          context.withQueryEngine((engine) => engine.routes()),
+        ),
+      ),
   );
 
   server.registerTool(
     "get_status",
     {
       description: "Get workspace, database, and last index run status.",
-      inputSchema: {},
+      inputSchema: {
+        workspaceId: z.string().optional(),
+      },
     },
-    async () =>
+    async ({ workspaceId }) =>
       asToolResult(
-        withWorkspaceQueryEngine(options.workspaceRoot, (engine, dbPath) =>
-          engine.status(options.workspaceRoot, dbPath),
-        ),
+        withResolvedWorkspace({ workspaceId }, (context) => context.status()),
       ),
   );
 
   server.registerTool(
     "run_index",
     {
-      description: "Run GraphTrace indexing for the current workspace.",
+      description: "Run GraphTrace indexing for the selected workspace.",
       inputSchema: {
+        workspaceId: z.string().optional(),
         mode: z.enum(["full", "incremental"]).default("incremental"),
       },
     },
-    async ({ mode }) =>
+    async ({ workspaceId, mode }) =>
       asToolResult(
-        await runWorkspaceIndex({
-          workspaceRoot: options.workspaceRoot,
-          mode,
-        }),
+        await withResolvedWorkspace({ workspaceId }, (context) =>
+          context.runIndex(mode),
+        ),
       ),
   );
 
   server.registerTool(
     "list_packages",
     {
-      description: "List packages discovered in the workspace.",
-      inputSchema: {},
+      description: "List packages discovered in the selected workspace.",
+      inputSchema: {
+        workspaceId: z.string().optional(),
+      },
     },
-    async () =>
-      asToolResult(withQueryEngine((engine) => engine.listPackages())),
+    async ({ workspaceId }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId }, (context) =>
+          context.withQueryEngine((engine) => engine.listPackages()),
+        ),
+      ),
   );
 
   server.registerTool(
     "get_package_overview",
     {
-      description: "Get the package overview for the current workspace.",
-      inputSchema: {},
+      description: "Get the package overview for the selected workspace.",
+      inputSchema: {
+        workspaceId: z.string().optional(),
+      },
     },
-    async () =>
-      asToolResult(withQueryEngine((engine) => engine.getPackageOverview())),
+    async ({ workspaceId }) =>
+      asToolResult(
+        withResolvedWorkspace({ workspaceId }, (context) =>
+          context.withQueryEngine((engine) => engine.getPackageOverview()),
+        ),
+      ),
   );
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
 
   return server;
+
+  function createRegisteredContext(
+    workspace: WorkspaceRecord,
+  ): ResolvedWorkspaceContext {
+    return {
+      workspaceId: workspace.id,
+      workspaceRoot: workspace.canonicalRootPath,
+      withQueryEngine: (action) =>
+        daemon.withWorkspaceQueryEngine(workspace.id, action),
+      status: () => daemon.status(workspace.id),
+      runIndex: (mode) =>
+        runWorkspaceIndex({
+          workspaceRoot: workspace.canonicalRootPath,
+          mode,
+          dbPath: workspace.dbPath,
+          persistWorkspaceArtifacts: false,
+        }),
+    };
+  }
+
+  function resolveWorkspaceContext(
+    hint: WorkspaceResolutionHint,
+  ): ResolvedWorkspaceContext {
+    if (hint.workspaceId) {
+      const workspace = daemon.getWorkspace(hint.workspaceId);
+      if (!workspace) {
+        throw new Error(`Unknown workspace: ${hint.workspaceId}`);
+      }
+      return createRegisteredContext(workspace);
+    }
+
+    const registeredWorkspaces = daemon
+      .listWorkspaces()
+      .filter((workspace) => workspace.status !== "missing");
+
+    if (registeredWorkspaces.length === 1) {
+      return createRegisteredContext(registeredWorkspaces[0]);
+    }
+
+    if (registeredWorkspaces.length > 1) {
+      const pathHint = deriveWorkspacePathHint(hint);
+      if (pathHint) {
+        const matchingWorkspaces = registeredWorkspaces.filter((workspace) =>
+          workspaceContainsPath(workspace, pathHint),
+        );
+
+        if (matchingWorkspaces.length === 1) {
+          return createRegisteredContext(matchingWorkspaces[0]);
+        }
+
+        if (matchingWorkspaces.length > 1) {
+          throw ambiguousWorkspaceError(matchingWorkspaces);
+        }
+      }
+
+      throw ambiguousWorkspaceError(registeredWorkspaces);
+    }
+
+    const legacyWorkspaceRoot = resolveLegacyWorkspaceRoot(
+      options.workspaceRoot,
+    );
+    if (legacyWorkspaceRoot) {
+      return createLegacyContext(legacyWorkspaceRoot);
+    }
+
+    throw new Error(
+      [
+        `No GraphTrace workspaces are registered in ${homeDir}.`,
+        "Use `add_workspace` or `graphtrace workspace add <path>` first.",
+      ].join(" "),
+    );
+  }
+}
+
+function createLegacyContext(workspaceRoot: string): ResolvedWorkspaceContext {
+  return {
+    workspaceRoot,
+    withQueryEngine: (action) =>
+      withWorkspaceQueryEngine(workspaceRoot, (engine) => action(engine)),
+    status: () =>
+      withWorkspaceQueryEngine(workspaceRoot, (engine, dbPath) =>
+        engine.status(workspaceRoot, dbPath),
+      ),
+    runIndex: (mode) =>
+      runWorkspaceIndex({
+        workspaceRoot,
+        mode,
+      }),
+  };
+}
+
+function resolveLegacyWorkspaceRoot(
+  workspaceRoot: string | undefined,
+): string | null {
+  if (!workspaceRoot) {
+    return null;
+  }
+
+  return existsSync(join(workspaceRoot, GRAPHTRACE_DB_PATH))
+    ? workspaceRoot
+    : null;
+}
+
+function deriveWorkspacePathHint(
+  hint: WorkspaceResolutionHint,
+): string | undefined {
+  if (hint.filePath) {
+    return hint.filePath;
+  }
+
+  if (hint.target && looksLikeWorkspacePath(hint.target)) {
+    return hint.target;
+  }
+
+  if (hint.symbolId?.startsWith("symbol:")) {
+    const encodedPath = hint.symbolId.slice("symbol:".length).split("#")[0];
+    return encodedPath || undefined;
+  }
+
+  return undefined;
+}
+
+function looksLikeWorkspacePath(target: string): boolean {
+  if (/^[A-Z]+ \//.test(target)) {
+    return false;
+  }
+
+  return (
+    target.startsWith(".") ||
+    target.includes("/") ||
+    /\.(ts|tsx|js|jsx|mjs|cjs|mts|cts|json)$/.test(target)
+  );
+}
+
+function workspaceContainsPath(
+  workspace: WorkspaceRecord,
+  pathHint: string,
+): boolean {
+  return existsSync(resolve(workspace.canonicalRootPath, pathHint));
+}
+
+function ambiguousWorkspaceError(workspaces: WorkspaceRecord[]): Error {
+  const candidates = workspaces
+    .map((workspace) => `${workspace.id} (${workspace.label})`)
+    .join(", ");
+
+  return new Error(
+    `GraphTrace MCP could not resolve a workspace automatically. Pass workspaceId. Candidates: ${candidates}`,
+  );
 }
 
 function toSymbolLocator(input: {

--- a/packages/mcp/test/mcp.test.ts
+++ b/packages/mcp/test/mcp.test.ts
@@ -1,3 +1,5 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -6,6 +8,7 @@ import { describe, expect, test } from "vitest";
 
 import { ensureWorkspaceInitialized } from "@graphtrace/config";
 import { indexWorkspace } from "@graphtrace/indexer";
+import { createGraphTraceDaemon } from "@graphtrace/server";
 
 const repoRoot = process.cwd();
 const fixtureRoot = join(repoRoot, "fixtures", "express-prisma-workspace");
@@ -21,11 +24,21 @@ interface ToolGraphItem {
   kind?: string;
   label?: string;
   path?: string;
+  filePath?: string;
   method?: string;
 }
 
 function readToolItems(payload: unknown): ToolGraphItem[] {
   return (payload as { items?: ToolGraphItem[] } | undefined)?.items ?? [];
+}
+
+function readToolText(payload: unknown): string {
+  return (payload as { content?: Array<{ text?: string }> } | undefined)
+    ?.content?.[0]?.text
+    ? String(
+        (payload as { content?: Array<{ text?: string }> }).content?.[0]?.text,
+      )
+    : "";
 }
 
 describe("mcp", () => {
@@ -61,6 +74,7 @@ describe("mcp", () => {
       const tools = await client.listTools();
 
       expect(tools.tools.map((tool) => tool.name).sort()).toEqual([
+        "add_workspace",
         "get_data_flow",
         "get_dependencies",
         "get_impact_analysis",
@@ -74,6 +88,9 @@ describe("mcp", () => {
         "graphtrace_get_symbol_impact",
         "graphtrace_search_symbols",
         "list_packages",
+        "list_workspaces",
+        "reindex_workspace",
+        "remove_workspace",
         "run_index",
         "search_code",
       ]);
@@ -236,6 +253,107 @@ describe("mcp", () => {
       await transport.close().catch(() => undefined);
     }
   }, 20_000);
+
+  test("serves multiple registered workspaces from one MCP home and resolves workspace scope explicitly", async () => {
+    const homeDir = await mkdtemp(join(tmpdir(), "graphtrace-mcp-home-"));
+    const daemon = createGraphTraceDaemon({ homeDir });
+
+    try {
+      const graphtrace = await daemon.addWorkspace(repoRoot, {
+        label: "GraphTrace",
+      });
+      const fixture = await daemon.addWorkspace(fixtureRoot, {
+        label: "fixture",
+      });
+
+      const transport = new StdioClientTransport({
+        command: "pnpm",
+        args: [
+          "exec",
+          "node",
+          "--import",
+          "tsx",
+          cliEntry,
+          "mcp",
+          "--home",
+          homeDir,
+        ],
+        cwd: repoRoot,
+        stderr: "pipe",
+      });
+      const client = new Client(
+        {
+          name: "graphtrace-multi-workspace-client",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {},
+        },
+      );
+
+      try {
+        await client.connect(transport);
+
+        const workspaces = await client.callTool({
+          name: "list_workspaces",
+          arguments: {},
+        });
+        const graphtraceSearch = await client.callTool({
+          name: "search_code",
+          arguments: {
+            query: "runCli",
+            workspaceId: graphtrace.id,
+          },
+        });
+        const autoResolvedSymbol = await client.callTool({
+          name: "graphtrace_get_symbol",
+          arguments: {
+            filePath: "packages/server/src/index.ts",
+            symbolName: "registerSingleWorkspaceRoutes",
+          },
+        });
+        const ambiguousRoutes = await client.callTool({
+          name: "get_routes",
+          arguments: {},
+        });
+
+        const workspaceItems = readToolItems(workspaces.structuredContent);
+        const graphtraceItems = readToolItems(
+          graphtraceSearch.structuredContent,
+        );
+        const autoResolvedItems = readToolItems(
+          autoResolvedSymbol.structuredContent,
+        );
+        const ambiguousText = readToolText(ambiguousRoutes);
+
+        expect(workspaces.isError).not.toBe(true);
+        expect(workspaceItems).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ id: graphtrace.id, label: "GraphTrace" }),
+            expect.objectContaining({ id: fixture.id, label: "fixture" }),
+          ]),
+        );
+        expect(graphtraceSearch.isError).not.toBe(true);
+        expect(
+          graphtraceItems.some((item) => item.id?.includes("runCli")),
+        ).toBe(true);
+        expect(autoResolvedSymbol.isError).not.toBe(true);
+        expect(
+          autoResolvedItems.some(
+            (item) =>
+              item.id?.includes("registerSingleWorkspaceRoutes") &&
+              item.filePath?.includes("packages/server/src/index.ts"),
+          ),
+        ).toBe(true);
+        expect(ambiguousRoutes.isError).toBe(true);
+        expect(ambiguousText).toContain("workspaceId");
+      } finally {
+        await transport.close().catch(() => undefined);
+      }
+    } finally {
+      daemon.close();
+    }
+  }, 30_000);
 
   test("exposes symbol search and lookup tools", async () => {
     await ensureWorkspaceInitialized(symbolGraphFixtureRoot);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@graphtrace/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@graphtrace/server':
+        specifier: workspace:*
+        version: link:../server
       '@graphtrace/shared':
         specifier: workspace:*
         version: link:../shared


### PR DESCRIPTION
## Summary
- move GraphTrace MCP to the shared workspace registry so one MCP entry can serve multiple indexed repos
- add user-scoped agent bootstrap for Codex, Claude Code, and Cursor via `graphtrace agent ... --scope user`
- document the shared-home workflow and cover it with CLI and MCP tests

## Test Plan
- pnpm lint
- pnpm typecheck
- pnpm test packages/mcp/test/mcp.test.ts packages/cli/test/agent-setup.test.ts packages/server/test/workspace-api.test.ts packages/cli/test/cli.test.ts
