### PR TITLE
fix: include symbol references in execution graphs

### DIFF
--- a/.changeset/green-moles-relate.md
+++ b/.changeset/green-moles-relate.md
@@ -1,0 +1,7 @@
+---
+"graphtrace": patch
+---
+
+Include symbol `references` edges in execution-context and impact graphs so Laravel command registrations such as `Kernel::$commands` surface through query APIs and MCP responses.
+
+Keep PHP reliability stronger for real Laravel and CrudBooster workspaces by preserving duplicate-route flow visibility alongside symbol-level debug traversal.

--- a/packages/query-engine/test/query-engine.test.ts
+++ b/packages/query-engine/test/query-engine.test.ts
@@ -329,6 +329,66 @@ describe("query engine", () => {
     }
   });
 
+  test("surfaces laravel command registrations through execution-context and impact queries", async () => {
+    await ensureWorkspaceInitialized(laravelFixtureRoot);
+    await indexWorkspace({ workspaceRoot: laravelFixtureRoot, full: true });
+
+    const store = openGraphStore(
+      join(laravelFixtureRoot, ".graphtrace", "index.db"),
+    );
+
+    try {
+      const queryEngine = createQueryEngine(store);
+      const execution = queryEngine.executionContextFromSymbol({
+        symbolId:
+          "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+      });
+      const impact = queryEngine.impactFromSymbol({
+        symbolId:
+          "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+      });
+
+      expect(execution.graph?.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "symbol:app/Console/Kernel.php#Kernel",
+            kind: "symbol",
+          }),
+        ]),
+      );
+      expect(execution.graph?.edges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "references",
+            sourceId: "symbol:app/Console/Kernel.php#Kernel",
+            targetId:
+              "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+          }),
+        ]),
+      );
+      expect(impact.graph?.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "symbol:app/Console/Kernel.php#Kernel",
+            kind: "symbol",
+          }),
+        ]),
+      );
+      expect(impact.graph?.edges).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: "references",
+            sourceId: "symbol:app/Console/Kernel.php#Kernel",
+            targetId:
+              "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+          }),
+        ]),
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   test("surfaces crudbooster roles and admin route flow through generic query APIs", async () => {
     await ensureWorkspaceInitialized(crudboosterLegacyFixtureRoot);
     await indexWorkspace({

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -867,7 +867,7 @@ export class GraphStore {
     const maxEdges = options?.maxEdges ?? 40;
     const rows = this.db
       .prepare(
-        "SELECT * FROM edges WHERE type IN ('routes_to', 'calls', 'queries')",
+        "SELECT * FROM edges WHERE type IN ('routes_to', 'calls', 'references', 'queries')",
       )
       .all() as unknown as EdgeRow[];
     const outgoing = new Map<string, EdgeRow[]>();

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -500,4 +500,100 @@ describe("storage", () => {
       store.close();
     }
   });
+
+  test("includes reference edges in execution-context and impact graphs", async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), "graphtrace-storage-"));
+    const store = openGraphStore(
+      join(workspaceRoot, ".graphtrace", "index.db"),
+    );
+
+    try {
+      store.upsertSymbol({
+        id: "symbol:app/Console/Kernel.php#Kernel",
+        name: "Kernel",
+        displayName: "Kernel",
+        kind: "class",
+        language: "php",
+        fileId: "file:app/Console/Kernel.php",
+        filePath: "app/Console/Kernel.php",
+        exported: true,
+      });
+      store.upsertSymbol({
+        id: "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+        name: "ForceSyncTableCommand",
+        displayName: "ForceSyncTableCommand",
+        kind: "class",
+        language: "php",
+        fileId: "file:app/Console/Commands/ForceSyncTableCommand.php",
+        filePath: "app/Console/Commands/ForceSyncTableCommand.php",
+        exported: true,
+      });
+      store.upsertSymbolEdge({
+        id: "edge:references:symbol:app/Console/Kernel.php#Kernel->symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+        type: "references",
+        sourceId: "symbol:app/Console/Kernel.php#Kernel",
+        sourceKind: "symbol",
+        targetId:
+          "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+        targetKind: "symbol",
+        confidence: 1,
+        confidenceLabel: "proven",
+        provenance: {
+          kind: "php-class-constant",
+          source: "php-parser",
+          evidence: ["ForceSyncTableCommand::class"],
+        },
+      });
+
+      expect(
+        store.executionContextFromSymbol(
+          "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+          {
+            maxNodes: 10,
+            maxEdges: 10,
+          },
+        ),
+      ).toMatchObject({
+        nodes: expect.arrayContaining([
+          expect.objectContaining({
+            id: "symbol:app/Console/Kernel.php#Kernel",
+          }),
+        ]),
+        edges: expect.arrayContaining([
+          expect.objectContaining({
+            type: "references",
+            sourceId: "symbol:app/Console/Kernel.php#Kernel",
+            targetId:
+              "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+          }),
+        ]),
+      });
+
+      expect(
+        store.impactFromSymbol(
+          "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+          {
+            maxNodes: 10,
+            maxEdges: 10,
+          },
+        ),
+      ).toMatchObject({
+        nodes: expect.arrayContaining([
+          expect.objectContaining({
+            id: "symbol:app/Console/Kernel.php#Kernel",
+          }),
+        ]),
+        edges: expect.arrayContaining([
+          expect.objectContaining({
+            type: "references",
+            sourceId: "symbol:app/Console/Kernel.php#Kernel",
+            targetId:
+              "symbol:app/Console/Commands/ForceSyncTableCommand.php#ForceSyncTableCommand",
+          }),
+        ]),
+      });
+    } finally {
+      store.close();
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- include symbol `references` edges when building execution-context and impact graphs
- add regression coverage for Laravel command registration traversal from `Kernel::$commands`
- add a patch changeset so the next merge releases a fixed version set update

## Why
`graphtrace@1.7.1` already indexed `Kernel -> ForceSyncTableCommand` reference edges for Laravel workspaces, but symbol execution/impact traversal only followed `routes_to`, `calls`, and `queries`. That made MCP and query APIs miss real Laravel command registration links in repos such as `sales.kimvanphuoc.com`.

## Verification
- `pnpm test packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts packages/query-engine/test/symbol-query.test.ts packages/storage/test/storage.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:smoke`
- benchmarked managed workspace for `/Users/tuannguyen8888/WorkSpace/TiemVang/KVP/sales.kimvanphuoc.com`
- benchmarked repo-local CLI index for `/Users/tuannguyen8888/WorkSpace/TiemVang/KVP/sales.kimvanphuoc.com`

## Real repo benchmark
After this change, the sales workspace shows:
- duplicate route flow for `GET /info-pawn-order-customers` includes both `routes/api.php` and `routes/web.php`
- execution-context and impact for `ForceSyncTableCommand` now include `app/Console/Kernel.php#Kernel` via a `references` edge
- service-object call traversal still works for `AdminGoldCountersController.getResumeCounter -> PurchaseDebtCalculationService.buildCounterPurchaseAmountExpression`
- repo-local CLI `init` + `index --full --json` now produces the same healthy-scale index shape as the managed workspace (`96 packages / 462 files / 2034 symbols / 70 routes / 1463 query edges`)
