### PR TITLE
feat: improve MCP reliability for agents

### DIFF
--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphtrace/web
 
+## 1.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @graphtrace/shared@1.8.0
+
 ## 1.7.2
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/web",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,8 @@
       "**/dist/**",
       "**/.graphtrace/**",
       "**/playwright-report/**",
-      "**/test-results/**"
+      "**/test-results/**",
+      "**/.worktrees/**"
     ]
   },
   "formatter": {

--- a/docs/superpowers/plans/2026-04-12-graph-first-workspace-ux.md
+++ b/docs/superpowers/plans/2026-04-12-graph-first-workspace-ux.md
@@ -1,0 +1,651 @@
+# Graph-First Workspace UX Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish issue `#43` by making the selected symbol workflow feel graph-first on desktop and mobile, while keeping the implementation maintainable and avoiding new UI debt.
+
+**Architecture:** Treat this as a presentation-state and workflow problem, not a CSS-only polish pass. Keep `App.tsx` as the data-loading and URL-sync coordinator, move workspace rendering into focused screen components, and derive a pure `WorkspacePresentationState` that controls whether the UI is in overview or focused investigation mode. Reuse the existing `GraphEnvelope` confidence and provenance data already returned by symbol graph queries so the inspector can explain trust directly without inventing a second backend path unless the current payload proves insufficient during implementation.
+
+**Tech Stack:** React 19, TypeScript, Vite, `@xyflow/react`, existing GraphTrace server routes, Vitest, Playwright, Biome
+
+---
+
+## Scope Notes
+
+This plan is the execution-focused follow-up to:
+
+- `docs/superpowers/specs/2026-04-08-graph-v2-design.md`
+- `docs/superpowers/plans/2026-04-08-graph-v2.md`
+
+Those earlier documents established the graph-first direction. This plan narrows the work to the concrete gap still visible in issue `#43` and the current UI screenshots:
+
+- graph and inspector still do not dominate strongly enough after selection
+- search, graph, and inspector still feel like adjacent panels instead of one flow
+- inspector still hides trust and provenance behind raw node lists
+- mobile still stacks useful state too low in the page
+- `apps/web/src/App.tsx` is already too large to absorb another round of inline branching safely
+
+## Guardrails
+
+- Do not solve this with CSS-only reordering layered on top of the current `App.tsx`.
+- Do not introduce a brand-new backend graph contract unless the existing `GraphEnvelope.edges[].provenance` data is proven insufficient.
+- Keep English and Vietnamese copy in parity.
+- Keep the bounded graph philosophy. This issue is about hierarchy and workflow clarity, not about rendering a larger graph.
+- Land the work in vertical slices that stay shippable and testable after each chunk.
+
+## File Map
+
+### Existing files to modify
+
+- `apps/web/src/App.tsx`
+  - keep only data fetching, URL sync, and event orchestration
+- `apps/web/src/app.css`
+  - replace the current one-size-fits-all page layout with explicit overview and focused investigation states
+- `apps/web/src/graph-workspace.tsx`
+  - coordinate graph emphasis, node highlight behavior, and focused canvas sizing
+- `apps/web/src/symbol-graph-controls.tsx`
+  - keep symbol controls compact and aligned with the promoted graph state
+- `apps/web/src/symbol-graph-inspector.tsx`
+  - render richer evidence rows instead of raw node-only lists
+- `apps/web/src/symbol-graph-view-model.ts`
+  - stop discarding edge confidence and provenance when building inspector sections
+- `apps/web/src/view-model.ts`
+  - keep search/workbench/starter helpers aligned with the new focused workflow
+- `apps/web/src/i18n.ts`
+  - add focused-state, trust, and mobile-friendly copy
+- `packages/server/test/web-ui.test.ts`
+  - extend the current view-model regression coverage
+- `playwright.config.ts`
+  - wire a real browser regression loop for desktop and mobile workflow assertions
+- `README.md`
+  - refresh screenshots only if the new UI materially changes the documented product surface
+
+### New files to create
+
+- `apps/web/src/workspace-screen.tsx`
+  - presentational shell for the selected workspace view
+- `apps/web/src/workspace-focus-view-model.ts`
+  - pure state builder for overview versus focused investigation mode
+- `apps/web/src/workspace-sidebar.tsx`
+  - left rail extracted from `App.tsx`
+- `apps/web/src/workspace-supporting-panels.tsx`
+  - search workbench and route explorer grouped as secondary panels
+- `apps/web/src/symbol-inspector-view-model.ts`
+  - transforms graph edges into trust-aware inspector rows with confidence and provenance summaries
+- `apps/web/test/graph-first-workspace.spec.ts`
+  - desktop and mobile browser regression coverage for the selected symbol workflow
+- `apps/web/test/helpers/graphtrace-fixture-server.ts`
+  - starts a fixture-backed GraphTrace server against built web assets for Playwright
+
+## Data and State Boundaries
+
+### `WorkspacePresentationState`
+
+Create a pure presentation-state helper in `apps/web/src/workspace-focus-view-model.ts`:
+
+```ts
+export interface WorkspacePresentationState {
+  mode: "overview" | "focused-route" | "focused-symbol" | "focused-file";
+  emphasizeGraph: boolean;
+  emphasizeInspector: boolean;
+  showStarterGuide: boolean;
+  supportingPanelsVariant: "full" | "secondary";
+  mobileSectionOrder: Array<"graph" | "inspector" | "supporting">;
+  graphCanvasDensity: "default" | "expanded";
+}
+```
+
+Rules:
+
+- idle state stays in `overview`
+- route, symbol, and file investigations all enter a focused mode
+- focused mode promotes graph and inspector and demotes search plus route explorer
+- mobile order becomes graph -> inspector -> supporting panels when focus exists
+- duplicate starter-guide narratives disappear once the user has a concrete selection
+
+### `SymbolInspectorRow`
+
+Create a trust-aware inspector row model in `apps/web/src/symbol-inspector-view-model.ts`:
+
+```ts
+export interface SymbolInspectorRow {
+  item: GraphItem;
+  confidenceLabel?: GraphConfidenceLabel;
+  relationshipKind: "caller" | "callee" | "route" | "sink";
+  evidenceSummary: string;
+  evidenceLines: string[];
+  focusAction: {
+    kind: "focus";
+    targetId: string;
+  };
+}
+```
+
+Rules:
+
+- derive `confidenceLabel` from the connecting edge, not from the node alone
+- derive `evidenceSummary` from `edge.provenance.kind`, `edge.provenance.source`, and the first useful evidence line
+- show weak-confidence warnings at row level and at section level when needed
+- keep rows actionable: select row, focus target, open file, or copy command
+
+## Chunk 1: Freeze the Workflow Contract and Extract the Screen Boundary
+
+### Task 1: Add failing tests for workspace presentation state
+
+**Files:**
+- Create: `apps/web/src/workspace-focus-view-model.ts`
+- Modify: `packages/server/test/web-ui.test.ts`
+- Test: `packages/server/test/web-ui.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add coverage for:
+
+- idle workspace state returns `mode: "overview"`
+- symbol inspection returns `mode: "focused-symbol"`
+- focused states promote graph and inspector
+- focused states switch mobile order to `["graph", "inspector", "supporting"]`
+- focused states suppress duplicate starter guidance
+
+Example assertion skeleton:
+
+```ts
+expect(
+  buildWorkspacePresentationState({
+    inspector: {
+      type: "search",
+      item: {
+        id: "symbol:apps/kiosk/src/pages/Result.tsx#Result.handlePrint",
+        kind: "symbol",
+        label: "Result.handlePrint",
+        path: "apps/kiosk/src/pages/Result.tsx",
+      },
+    },
+  }),
+).toMatchObject({
+  mode: "focused-symbol",
+  emphasizeGraph: true,
+  emphasizeInspector: true,
+  mobileSectionOrder: ["graph", "inspector", "supporting"],
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts -t "workspace presentation state"`
+
+Expected: FAIL because `buildWorkspacePresentationState` does not exist yet
+
+- [ ] **Step 3: Implement the minimal pure state builder**
+
+Create `apps/web/src/workspace-focus-view-model.ts` and export:
+
+- `buildWorkspacePresentationState`
+- `hasConcreteSelection`
+- any tiny discriminated helpers needed to keep React components branch-light
+
+Do not touch layout markup yet. This task only defines the contract.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts -t "workspace presentation state"`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/workspace-focus-view-model.ts packages/server/test/web-ui.test.ts
+git commit -m "Add workspace presentation state model"
+```
+
+### Task 2: Extract `WorkspaceScreen` and the left rail before behavior changes
+
+**Files:**
+- Create: `apps/web/src/workspace-screen.tsx`
+- Create: `apps/web/src/workspace-sidebar.tsx`
+- Modify: `apps/web/src/App.tsx`
+- Modify: `apps/web/src/app.css`
+- Test: `packages/server/test/web-ui.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests that assert the current localized copy and structural labels still exist after extraction:
+
+- graph state
+- triage lens
+- route filter
+- inspector
+
+The intent is to protect against accidental UI regressions during the extraction.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts -t "graph state"`
+
+Expected: FAIL only if copy or exported component wiring is broken during extraction
+
+- [ ] **Step 3: Move markup out of `App.tsx` without changing behavior**
+
+Move the selected-workspace render branch into `workspace-screen.tsx` and the left rail into `workspace-sidebar.tsx`.
+
+`App.tsx` should keep:
+
+- remote data loading
+- search and inspector state
+- URL persistence
+- event callbacks passed into extracted components
+
+It should stop owning large blocks of JSX for:
+
+- the left rail
+- graph panel shell
+- search/workbench shell
+- route explorer shell
+- inspector shell
+
+- [ ] **Step 4: Run verification**
+
+Run:
+
+- `pnpm vitest run packages/server/test/web-ui.test.ts`
+- `pnpm typecheck`
+
+Expected:
+
+- tests PASS
+- typecheck PASS
+- `App.tsx` becomes materially smaller and mostly orchestration-only
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/workspace-screen.tsx apps/web/src/workspace-sidebar.tsx apps/web/src/App.tsx apps/web/src/app.css packages/server/test/web-ui.test.ts
+git commit -m "Extract workspace screen and sidebar shell"
+```
+
+---
+
+## Chunk 2: Make the Selected Symbol Workflow Actually Graph-First
+
+### Task 3: Promote graph plus inspector and demote supporting panels
+
+**Files:**
+- Modify: `apps/web/src/workspace-screen.tsx`
+- Create: `apps/web/src/workspace-supporting-panels.tsx`
+- Modify: `apps/web/src/app.css`
+- Modify: `apps/web/src/graph-workspace.tsx`
+- Modify: `apps/web/src/workspace-focus-view-model.ts`
+- Test: `packages/server/test/web-ui.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add view-model coverage for:
+
+- focused route and symbol states using `supportingPanelsVariant: "secondary"`
+- focused states using `graphCanvasDensity: "expanded"`
+- idle state keeping `supportingPanelsVariant: "full"`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts -t "supportingPanelsVariant"`
+
+Expected: FAIL on missing focused-layout fields
+
+- [ ] **Step 3: Implement the focused layout**
+
+In `workspace-screen.tsx` and `app.css`:
+
+- add explicit overview and focused layout classes or data attributes
+- keep the left rail visible, but visually secondary
+- make the graph panel taller and visually dominant in focused mode
+- make the inspector sticky or visually anchored beside the graph on wide screens
+- move search workbench and route explorer into `workspace-supporting-panels.tsx`
+- render the supporting panels as a secondary band below the graph plus inspector instead of equal-weight primary columns
+
+Do not hide search or routes completely. They remain available, but they stop competing with the active graph state.
+
+- [ ] **Step 4: Remove duplicate guidance**
+
+In focused mode:
+
+- do not render the starter guide in both the graph empty state and the inspector empty state
+- compress the workbench guidance into one clear “next action” block instead of layered intro + quick picks + triage copy
+
+In overview mode:
+
+- keep the onboarding affordance, but trim narrative density
+
+- [ ] **Step 5: Run verification**
+
+Run:
+
+- `pnpm vitest run packages/server/test/web-ui.test.ts`
+- `pnpm typecheck`
+- `pnpm web:build`
+
+Expected:
+
+- focused states visually promote graph and inspector
+- no build errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/workspace-screen.tsx apps/web/src/workspace-supporting-panels.tsx apps/web/src/app.css apps/web/src/graph-workspace.tsx apps/web/src/workspace-focus-view-model.ts packages/server/test/web-ui.test.ts
+git commit -m "Promote focused graph and inspector workflow"
+```
+
+### Task 4: Strengthen active-state coordination across graph, search, and inspector
+
+**Files:**
+- Modify: `apps/web/src/workspace-screen.tsx`
+- Modify: `apps/web/src/graph-workspace.tsx`
+- Modify: `apps/web/src/symbol-graph-controls.tsx`
+- Modify: `apps/web/src/app.css`
+- Modify: `apps/web/src/view-model.ts`
+- Modify: `apps/web/src/i18n.ts`
+- Test: `packages/server/test/web-ui.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add coverage for shared selection behavior:
+
+- search result selection and graph focus use the same selected item id
+- symbol selection resets symbol graph mode and confidence defaults consistently
+- focused states expose one clear selected title across graph and inspector
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts -t "selected title"`
+
+Expected: FAIL on missing shared selection helpers or inconsistent defaults
+
+- [ ] **Step 3: Implement shared active-state affordances**
+
+Add the minimal state and styling needed so the same selection is visually obvious across:
+
+- search results
+- graph-local search hits
+- graph focus node
+- inspector title and rows
+- route explorer rows when the selected item is a route
+
+Use existing localized `focus` copy where an explicit focus action improves clarity.
+
+Avoid creating another global store. Keep the source of truth in existing React state and derive visual flags from it.
+
+- [ ] **Step 4: Add mobile focus handoff**
+
+On small screens, after selecting a search result, route, or graph node:
+
+- scroll the graph container into view when entering focus mode
+- keep the inspector directly after the graph
+- avoid forcing the user to scroll through search guidance before seeing useful graph state
+
+Keep this behavior progressive. Only trigger it when focus actually changes.
+
+- [ ] **Step 5: Run verification**
+
+Run:
+
+- `pnpm vitest run packages/server/test/web-ui.test.ts`
+- `pnpm typecheck`
+
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/workspace-screen.tsx apps/web/src/graph-workspace.tsx apps/web/src/symbol-graph-controls.tsx apps/web/src/app.css apps/web/src/view-model.ts apps/web/src/i18n.ts packages/server/test/web-ui.test.ts
+git commit -m "Coordinate active focus across graph search and inspector"
+```
+
+---
+
+## Chunk 3: Make Trust Legible Instead of Implicit
+
+### Task 5: Add a symbol inspector evidence view-model
+
+**Files:**
+- Create: `apps/web/src/symbol-inspector-view-model.ts`
+- Modify: `apps/web/src/symbol-graph-view-model.ts`
+- Modify: `packages/server/test/web-ui.test.ts`
+- Test: `packages/server/test/web-ui.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests that prove the current node-only inspector is insufficient, then lock the new behavior:
+
+- caller and callee rows retain the connecting edge confidence label
+- evidence summary is derived from `edge.provenance.kind` and `edge.provenance.source`
+- weak-confidence edges surface warnings without hiding the row
+- routes and sinks remain empty in reference mode
+
+Example expectation shape:
+
+```ts
+expect(sections[0].rows[0]).toMatchObject({
+  item: expect.objectContaining({
+    id: "symbol:apps/api/src/routes/users.ts#auditedListUsers",
+  }),
+  confidenceLabel: "inferred-strong",
+  evidenceSummary: expect.stringContaining("route-handler"),
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts -t "confidence label"`
+
+Expected: FAIL because inspector sections currently expose only `items`
+
+- [ ] **Step 3: Implement the trust-aware row builder**
+
+Create `symbol-inspector-view-model.ts` and refactor `symbol-graph-view-model.ts` so section building retains:
+
+- the related node
+- the edge that connects the node to the current root symbol
+- a short trust summary
+- whether the row should show a weak-confidence warning
+
+Do not fetch per-edge detail from the server yet. First use the edge provenance already present in the graph payload. Only add `getWorkspaceSymbolEdge` later if a real gap remains after implementation.
+
+- [ ] **Step 4: Run verification**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts`
+
+Expected: PASS with no regressions to the current symbol graph controls tests
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/symbol-inspector-view-model.ts apps/web/src/symbol-graph-view-model.ts packages/server/test/web-ui.test.ts
+git commit -m "Preserve trust evidence in symbol inspector state"
+```
+
+### Task 6: Render provenance and confidence in the inspector UI
+
+**Files:**
+- Modify: `apps/web/src/symbol-graph-inspector.tsx`
+- Modify: `apps/web/src/symbol-graph-controls.tsx`
+- Modify: `apps/web/src/app.css`
+- Modify: `apps/web/src/i18n.ts`
+- Modify: `apps/web/src/workspace-screen.tsx`
+- Test: `packages/server/test/web-ui.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add assertions for new UI copy and state labels:
+
+- confidence badge labels
+- provenance microcopy
+- row-level focus action label
+- focused symbol summary copy
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run packages/server/test/web-ui.test.ts -t "provenance"`
+
+Expected: FAIL on missing localized copy and missing row properties
+
+- [ ] **Step 3: Implement the UI**
+
+Update `symbol-graph-inspector.tsx` so each row shows:
+
+- node chip
+- label and path
+- confidence badge
+- one-line provenance summary
+- optional weak-confidence warning
+- explicit focus/select action when it improves navigation clarity
+
+Update `symbol-graph-controls.tsx` so the currently selected symbol summary does not compete visually with the new inspector trust content.
+
+- [ ] **Step 4: Run verification**
+
+Run:
+
+- `pnpm vitest run packages/server/test/web-ui.test.ts`
+- `pnpm typecheck`
+- `pnpm web:build`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/symbol-graph-inspector.tsx apps/web/src/symbol-graph-controls.tsx apps/web/src/app.css apps/web/src/i18n.ts apps/web/src/workspace-screen.tsx packages/server/test/web-ui.test.ts
+git commit -m "Show symbol provenance and confidence in inspector"
+```
+
+---
+
+## Chunk 4: Lock the UX with Real Browser Coverage and Update Docs
+
+### Task 7: Add Playwright regression coverage for desktop and mobile
+
+**Files:**
+- Create: `apps/web/test/helpers/graphtrace-fixture-server.ts`
+- Create: `apps/web/test/graph-first-workspace.spec.ts`
+- Modify: `playwright.config.ts`
+- Test: `apps/web/test/graph-first-workspace.spec.ts`
+
+- [ ] **Step 1: Write the failing browser tests**
+
+Add one desktop and one mobile test.
+
+Desktop assertion set:
+
+- open the fixture workspace screen
+- search and select `Result.handlePrint`
+- graph canvas is visible without scrolling past the supporting panels
+- inspector shows the selected symbol plus confidence or provenance text
+
+Mobile assertion set:
+
+- same selection flow in a narrow viewport
+- after selection, graph is visible first
+- inspector appears before the workbench and route explorer in DOM or rendered order
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm playwright test apps/web/test/graph-first-workspace.spec.ts`
+
+Expected: FAIL because the harness and the focused layout assertions do not exist yet
+
+- [ ] **Step 3: Build the fixture server harness**
+
+Create `apps/web/test/helpers/graphtrace-fixture-server.ts` that:
+
+- ensures a known fixture workspace is initialized and indexed
+- starts `createGraphTraceApp` against built web assets
+- binds to `127.0.0.1:4310`
+- shuts down cleanly after Playwright completes
+
+Update `playwright.config.ts` to use this harness as `webServer`.
+
+- [ ] **Step 4: Re-run browser tests**
+
+Run:
+
+- `pnpm web:build`
+- `pnpm playwright test apps/web/test/graph-first-workspace.spec.ts`
+
+Expected: PASS on both desktop and mobile assertions
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/test/helpers/graphtrace-fixture-server.ts apps/web/test/graph-first-workspace.spec.ts playwright.config.ts
+git commit -m "Add browser regression coverage for graph-first workflow"
+```
+
+### Task 8: Refresh screenshots and perform full verification
+
+**Files:**
+- Modify: `README.md`
+- Modify: `docs/screenshots/workspace-overview-en.png`
+- Modify: `docs/screenshots/symbol-execution-graph-en.png`
+
+- [ ] **Step 1: Capture updated screenshots if the UI changed materially**
+
+Use the Playwright flow or a manual local run to update:
+
+- `docs/screenshots/workspace-overview-en.png`
+- `docs/screenshots/symbol-execution-graph-en.png`
+
+Only do this after the focused layout is stable.
+
+- [ ] **Step 2: Run the full verification suite**
+
+Run:
+
+- `pnpm lint`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm web:build`
+- `pnpm playwright test`
+
+Expected:
+
+- all commands PASS
+- no i18n gaps
+- desktop and mobile workflow stays readable
+
+- [ ] **Step 3: Update README only if screenshots changed**
+
+If the visible UI changed enough that the current README shots are misleading:
+
+- replace the screenshot assets
+- keep the existing README narrative unless the UI workflow wording is now stale
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/screenshots/workspace-overview-en.png docs/screenshots/symbol-execution-graph-en.png
+git commit -m "Refresh graph-first workspace screenshots"
+```
+
+## Execution Order Summary
+
+1. Lock the presentation-state contract with tests.
+2. Extract the workspace screen boundary before changing behavior.
+3. Promote graph plus inspector and demote supporting panels.
+4. Unify active-state affordances across graph, search, and inspector.
+5. Preserve trust metadata in the symbol inspector model.
+6. Render provenance and confidence so users can judge the graph quickly.
+7. Add desktop and mobile Playwright regression coverage.
+8. Refresh product screenshots only after the UI is stable.
+
+## Expected End State
+
+After this plan lands:
+
+- selecting a symbol immediately promotes graph plus inspector as the primary surface
+- search result -> graph -> inspector reads as one continuous investigation loop
+- provenance and confidence are visible where users make navigation decisions
+- mobile shows useful graph state before the user scrolls through support content
+- `App.tsx` remains an orchestration file instead of becoming the permanent dumping ground for another UI rewrite
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-12-graph-first-workspace-ux.md`. Ready to execute?

--- a/docs/superpowers/plans/2026-04-12-php-laravel-crudbooster.md
+++ b/docs/superpowers/plans/2026-04-12-php-laravel-crudbooster.md
@@ -1,0 +1,669 @@
+# PHP, Laravel, and CrudBooster Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend GraphTrace so it can deeply analyze PHP repositories, especially Laravel applications and CrudBooster-based codebases, while preserving current JS/TS capabilities and existing query surfaces.
+
+**Architecture:** First harden mixed-language detection and reduce framework false positives, then refactor the current indexer into internal language and framework capability boundaries. After that, add a PHP language analyzer, a Laravel framework extractor, and a CrudBooster-specialized extractor that all emit normalized graph facts into the existing SQLite-backed store and query engine.
+
+**Tech Stack:** TypeScript, Node.js, SQLite, Vitest, `php-parser`, existing GraphTrace CLI, MCP, server, and web packages
+
+---
+
+## Scope Strategy
+
+This plan is intentionally phased. Do not start Laravel or CrudBooster work
+before detection hardening and indexer boundary extraction are in place.
+
+- Chunk 1 = Detection and indexer boundary cleanup
+- Chunk 2 = PHP language foundation
+- Chunk 3 = Laravel usable graph
+- Chunk 4 = CrudBooster support and hardening
+
+Each chunk should stop for review before proceeding.
+
+## File Map
+
+### Existing files to modify
+
+- `packages/shared/src/index.ts`
+  - add PHP language enums and any shared graph metadata needed by PHP support
+- `packages/config/src/index.ts`
+  - extend framework defaults if needed for Laravel and CrudBooster
+- `packages/indexer/src/workspace.ts`
+  - mixed-language discovery, PHP unit scoring, framework signal detection
+- `packages/indexer/src/index.ts`
+  - convert into orchestrator over language and framework analyzers
+- `packages/indexer/test/indexer.test.ts`
+  - end-to-end indexing coverage for PHP, Laravel, and CrudBooster fixtures
+- `packages/cli/src/index.ts`
+  - watch snapshot and source extension handling for PHP files
+- `packages/query-engine/src/index.ts`
+  - only if PHP-specific graph traversal or filtering needs minor shaping
+- `packages/query-engine/test/query-engine.test.ts`
+  - ensure search, routes, impact, and flow stay generic over PHP facts
+- `packages/mcp/src/index.ts`
+  - only if tool descriptions or payload shaping need small updates
+- `packages/mcp/test/mcp.test.ts`
+  - verify generic tools return PHP and Laravel facts cleanly
+- `packages/server/src/index.ts`
+  - only if server filtering assumes JS/TS-only languages
+- `packages/server/test/server.test.ts`
+  - HTTP assertions over generic graph output with PHP facts
+- `packages/server/test/web-ui.test.ts`
+  - UI messaging or display assumptions for mixed-language repos
+- `apps/web/src/workspace-screen.tsx`
+  - graph-first workspace surface that presents routes, search, and inspector
+- `apps/web/src/workspace-focus-view-model.ts`
+  - workspace presentation state for focused graph and inspector layouts
+- `apps/web/src/view-model.ts`
+  - route, search, package, and inspector display helpers used by the workspace UI
+- `apps/web/test/graph-first-workspace.spec.ts`
+  - Playwright coverage for the current graph-first workspace flow
+- `playwright.config.ts`
+  - browser test harness for graph-first workspace verification
+- `packages/storage/src/index.ts`
+  - only if broader symbol language persistence or metadata handling is needed
+- `packages/storage/test/storage.test.ts`
+  - storage round-trip for PHP symbol language metadata
+
+### New files to create
+
+- `packages/indexer/src/languages/js-ts/analyzer.ts`
+  - adapter over current JS/TS indexing behavior
+- `packages/indexer/src/languages/php/analyzer.ts`
+  - PHP analysis entrypoint and orchestration
+- `packages/indexer/src/languages/php/ast.ts`
+  - parser wrapper and AST adapter around `php-parser`
+- `packages/indexer/src/languages/php/extract-symbols.ts`
+  - PHP class, method, namespace, and function extraction
+- `packages/indexer/src/languages/php/extract-references.ts`
+  - PHP reference and dependency extraction
+- `packages/indexer/src/languages/php/extract-query-hints.ts`
+  - Eloquent and DB query hint extraction
+- `packages/indexer/src/frameworks/php/laravel/detect.ts`
+  - Laravel framework matching
+- `packages/indexer/src/frameworks/php/laravel/extract-routes.ts`
+  - Laravel route extraction
+- `packages/indexer/src/frameworks/php/laravel/extract-flow.ts`
+  - route-to-controller-to-service or query stitching
+- `packages/indexer/src/frameworks/php/crudbooster/detect.ts`
+  - CrudBooster matching
+- `packages/indexer/src/frameworks/php/crudbooster/extract-modules.ts`
+  - CrudBooster module and controller extraction
+- `packages/indexer/src/frameworks/php/crudbooster/extract-flow.ts`
+  - CrudBooster graph enrichment
+- `fixtures/php-basic-workspace/`
+  - baseline pure PHP fixture
+- `fixtures/php-mixed-workspace/`
+  - mixed repo fixture with JS/TS and PHP boundaries
+- `fixtures/laravel-workspace/`
+  - basic Laravel application fixture
+- `fixtures/laravel-resource-workspace/`
+  - resource-route-heavy fixture
+- `fixtures/crudbooster-legacy-workspace/`
+  - archived-style CrudBooster fixture based on public conventions
+
+### Optional follow-up fixtures
+
+- `fixtures/crudbooster-modern-workspace/`
+  - only create if the team has a legally safe sample repository or a synthetic
+    fixture that reflects public conventions without copying proprietary source
+
+## Chunk 1: Detection and Indexer Boundary Cleanup
+
+### Task 1: Fix mixed-language unit detection before adding PHP
+
+**Files:**
+- Modify: `packages/shared/src/index.ts`
+- Modify: `packages/indexer/src/workspace.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+
+- [ ] **Step 1: Write failing tests for mixed-language unit classification**
+
+Add tests covering:
+- root workspace with nested non-JS markers does not collapse into useless
+  `unknown` classification when strong child units exist
+- PHP units can be classified as `php`
+- existing JS/TS fixtures still classify as `js-ts`
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: FAIL because `UnitLanguage` does not yet support `php` and current
+mixed-language scoring degrades some roots incorrectly
+
+- [ ] **Step 3: Implement minimal type and discovery changes**
+
+Update:
+- `UnitLanguage` to include `php`
+- symbol language enums as needed for persistence
+- workspace scoring so non-JS markers do not automatically poison otherwise
+  useful workspace roots
+- PHP discovery signals such as `composer.json`, `artisan`, `bootstrap/app.php`,
+  `routes/*.php`, and `app/**/*.php`
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: PASS for mixed-language and `php` classification assertions
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/shared/src/index.ts packages/indexer/src/workspace.ts packages/indexer/test/indexer.test.ts
+git commit -m "Add PHP unit detection and fix mixed-language scoring"
+```
+
+### Task 2: Reduce framework false positives before expanding framework coverage
+
+**Files:**
+- Modify: `packages/indexer/src/workspace.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Modify: `packages/cli/test/cli.test.ts`
+
+- [ ] **Step 1: Write failing tests for stricter framework matching**
+
+Add assertions covering:
+- GraphTrace source packages are not matched as application frameworks only
+  because detector strings appear in source text
+- Laravel requires strong project-layout or dependency signals
+- CrudBooster requires strong convention signals
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/cli/test/cli.test.ts`
+Expected: FAIL because current framework detection is still string-heavy and
+over-matches
+
+- [ ] **Step 3: Tighten framework matching heuristics**
+
+Prefer:
+- dependency markers
+- bootstrap files
+- directory conventions
+- route files
+- framework-owned entrypoints
+
+Avoid:
+- matching internal detector code as app framework usage
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/cli/test/cli.test.ts`
+Expected: PASS with reduced false positives
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/workspace.ts packages/indexer/test/indexer.test.ts packages/cli/test/cli.test.ts
+git commit -m "Tighten framework matching heuristics"
+```
+
+### Task 3: Extract current JS/TS indexing into an internal analyzer boundary
+
+**Files:**
+- Create: `packages/indexer/src/languages/js-ts/analyzer.ts`
+- Modify: `packages/indexer/src/index.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+
+- [ ] **Step 1: Write failing regression tests around current JS/TS indexing behavior**
+
+Add assertions covering:
+- existing route, symbol, and query extraction still works after refactor
+- orchestrator delegates to JS/TS path without changing output counts on current
+  fixtures
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: FAIL once the refactor scaffolding is introduced but the analyzer
+boundary is not fully wired
+
+- [ ] **Step 3: Refactor `index.ts` into an orchestrator**
+
+Move existing JS/TS-specific logic into a dedicated analyzer module and leave
+`packages/indexer/src/index.ts` responsible for:
+- config loading
+- graph store lifecycle
+- unit iteration
+- analyzer selection
+- fact persistence
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: PASS with no JS/TS regressions
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/index.ts packages/indexer/src/languages/js-ts/analyzer.ts packages/indexer/test/indexer.test.ts
+git commit -m "Refactor indexer into language analyzers"
+```
+
+## Chunk 2: PHP Language Foundation
+
+### Task 4: Add PHP file discovery to watch and snapshot flows
+
+**Files:**
+- Modify: `packages/cli/src/index.ts`
+- Modify: `packages/cli/test/watch.test.ts`
+- Modify: `packages/cli/test/cli.test.ts`
+
+- [ ] **Step 1: Write failing tests for PHP watch coverage**
+
+Add tests covering:
+- workspace snapshot includes `.php` files
+- watch diff detects added, changed, and removed PHP files
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/cli/test/watch.test.ts packages/cli/test/cli.test.ts`
+Expected: FAIL because current snapshot logic only includes JS/TS extensions
+
+- [ ] **Step 3: Extend source extension handling**
+
+Update watch and snapshot logic to include `.php` while preserving current JS/TS
+behavior.
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/cli/test/watch.test.ts packages/cli/test/cli.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/index.ts packages/cli/test/watch.test.ts packages/cli/test/cli.test.ts
+git commit -m "Track PHP files in watch snapshots"
+```
+
+### Task 5: Introduce PHP AST adapter and symbol extraction
+
+**Files:**
+- Create: `packages/indexer/src/languages/php/ast.ts`
+- Create: `packages/indexer/src/languages/php/extract-symbols.ts`
+- Create: `packages/indexer/src/languages/php/analyzer.ts`
+- Modify: `packages/indexer/src/index.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Create: `fixtures/php-basic-workspace/`
+
+- [ ] **Step 1: Write failing PHP symbol extraction tests**
+
+Add fixture assertions for:
+- namespaces
+- classes
+- methods
+- interfaces or traits
+- stable symbol IDs for class and method declarations
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: FAIL because there is no PHP analyzer or parser integration yet
+
+- [ ] **Step 3: Implement the PHP AST adapter and analyzer**
+
+Use `php-parser` behind `ast.ts` and implement:
+- parser wrapper
+- AST normalization helpers
+- symbol extraction for PHP classes, methods, and functions
+- file registration into the graph store using existing normalized record shapes
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: PASS for baseline PHP symbol extraction
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/index.ts packages/indexer/src/languages/php/ast.ts packages/indexer/src/languages/php/extract-symbols.ts packages/indexer/src/languages/php/analyzer.ts packages/indexer/test/indexer.test.ts fixtures/php-basic-workspace
+git commit -m "Add baseline PHP symbol indexing"
+```
+
+### Task 6: Add PHP reference and query hint extraction
+
+**Files:**
+- Create: `packages/indexer/src/languages/php/extract-references.ts`
+- Create: `packages/indexer/src/languages/php/extract-query-hints.ts`
+- Modify: `packages/indexer/src/languages/php/analyzer.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Modify: `packages/storage/test/storage.test.ts`
+- Create: `fixtures/php-mixed-workspace/`
+
+- [ ] **Step 1: Write failing tests for PHP references and query hints**
+
+Add tests covering:
+- `use`, `extends`, and static call relationships
+- Eloquent-like or DB-like query hints
+- mixed PHP and JS/TS workspace indexing remains stable
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/storage/test/storage.test.ts`
+Expected: FAIL because PHP references and query hints are not emitted yet
+
+- [ ] **Step 3: Implement PHP references and query hint extraction**
+
+Emit normalized:
+- `references`
+- `calls`
+- `queries`
+
+with conservative confidence and clear provenance.
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/storage/test/storage.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/languages/php/extract-references.ts packages/indexer/src/languages/php/extract-query-hints.ts packages/indexer/src/languages/php/analyzer.ts packages/indexer/test/indexer.test.ts packages/storage/test/storage.test.ts fixtures/php-mixed-workspace
+git commit -m "Add PHP references and query hints"
+```
+
+## Chunk 3: Laravel Usable Graph
+
+### Task 7: Detect Laravel units with strong project signals
+
+**Files:**
+- Create: `packages/indexer/src/frameworks/php/laravel/detect.ts`
+- Modify: `packages/indexer/src/workspace.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Create: `fixtures/laravel-workspace/`
+
+- [ ] **Step 1: Write failing tests for Laravel detection**
+
+Add assertions covering:
+- Laravel fixture units match `framework:laravel`
+- non-Laravel PHP fixtures do not match Laravel
+- mixed workspaces keep correct unit boundaries
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: FAIL because Laravel framework matching does not exist yet
+
+- [ ] **Step 3: Implement Laravel detection**
+
+Use strong signals such as:
+- Composer dependencies
+- `artisan`
+- `bootstrap/app.php`
+- `routes/*.php`
+- `app/Http/Controllers`
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/frameworks/php/laravel/detect.ts packages/indexer/src/workspace.ts packages/indexer/test/indexer.test.ts fixtures/laravel-workspace
+git commit -m "Detect Laravel framework units"
+```
+
+### Task 8: Extract Laravel routes, including resource routes
+
+**Files:**
+- Create: `packages/indexer/src/frameworks/php/laravel/extract-routes.ts`
+- Modify: `packages/indexer/src/languages/php/analyzer.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Create: `fixtures/laravel-resource-workspace/`
+- Modify: `packages/query-engine/test/query-engine.test.ts`
+
+- [ ] **Step 1: Write failing tests for Laravel route extraction**
+
+Add assertions covering:
+- explicit route methods
+- grouped routes with prefixes
+- controller routes
+- `resource` and `apiResource` helpers
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts`
+Expected: FAIL because Laravel routes are not indexed yet
+
+- [ ] **Step 3: Implement route extraction**
+
+Emit normalized route facts with:
+- method
+- path
+- handler name
+- handler symbol ID
+- file path
+- framework provenance
+
+Support the common Laravel helper patterns from the approved spec.
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts`
+Expected: PASS for Laravel route listing and search coverage
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/frameworks/php/laravel/extract-routes.ts packages/indexer/src/languages/php/analyzer.ts packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts fixtures/laravel-resource-workspace
+git commit -m "Add Laravel route extraction"
+```
+
+### Task 9: Stitch Laravel route-to-controller-to-query flow
+
+**Files:**
+- Create: `packages/indexer/src/frameworks/php/laravel/extract-flow.ts`
+- Modify: `packages/indexer/src/languages/php/analyzer.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Modify: `packages/query-engine/test/query-engine.test.ts`
+- Modify: `packages/mcp/test/mcp.test.ts`
+
+- [ ] **Step 1: Write failing tests for Laravel flow and impact**
+
+Add assertions covering:
+- route to controller action edges
+- controller action to service or model call edges when statically visible
+- query hints reachable from a route flow
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts packages/mcp/test/mcp.test.ts`
+Expected: FAIL because Laravel flow stitching does not exist yet
+
+- [ ] **Step 3: Implement conservative Laravel flow extraction**
+
+Support:
+- invokable controllers
+- array action references
+- string controller action references where obvious
+- `$this` intra-controller method dispatch where statically visible
+- implicit model binding only when backed by route params and type hints
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts packages/mcp/test/mcp.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/frameworks/php/laravel/extract-flow.ts packages/indexer/src/languages/php/analyzer.ts packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts packages/mcp/test/mcp.test.ts
+git commit -m "Add Laravel route flow stitching"
+```
+
+## Chunk 4: CrudBooster Support and Hardening
+
+### Task 10: Detect legacy CrudBooster conventions safely
+
+**Files:**
+- Create: `packages/indexer/src/frameworks/php/crudbooster/detect.ts`
+- Modify: `packages/indexer/src/workspace.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Create: `fixtures/crudbooster-legacy-workspace/`
+
+- [ ] **Step 1: Write failing tests for CrudBooster detection**
+
+Add assertions covering:
+- legacy public conventions such as `CBController` inheritance or equivalent
+  markers trigger `framework:crudbooster`
+- ordinary Laravel fixtures do not match CrudBooster accidentally
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: FAIL because CrudBooster detection does not exist yet
+
+- [ ] **Step 3: Implement legacy CrudBooster detection**
+
+Use strong convention signals from public knowledge only. Do not copy
+proprietary source. Favor explainable matching over broad heuristics.
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/frameworks/php/crudbooster/detect.ts packages/indexer/src/workspace.ts packages/indexer/test/indexer.test.ts fixtures/crudbooster-legacy-workspace
+git commit -m "Detect CrudBooster legacy conventions"
+```
+
+### Task 11: Extract CrudBooster modules, controllers, and graph relationships
+
+**Files:**
+- Create: `packages/indexer/src/frameworks/php/crudbooster/extract-modules.ts`
+- Create: `packages/indexer/src/frameworks/php/crudbooster/extract-flow.ts`
+- Modify: `packages/indexer/src/languages/php/analyzer.ts`
+- Modify: `packages/indexer/test/indexer.test.ts`
+- Modify: `packages/query-engine/test/query-engine.test.ts`
+
+- [ ] **Step 1: Write failing tests for CrudBooster module graph extraction**
+
+Add assertions covering:
+- module or admin controller discovery
+- controller to model relationships where visible
+- CRUD lifecycle method symbols when conventional names exist
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts`
+Expected: FAIL because CrudBooster graph extraction does not exist yet
+
+- [ ] **Step 3: Implement module and flow extraction**
+
+Emit normalized graph facts for:
+- controllers
+- modules
+- model relationships
+- route or admin entrypoint relationships where recoverable
+
+Keep provenance explicit because some of these relationships will be inferred
+from framework conventions.
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/indexer/src/frameworks/php/crudbooster/extract-modules.ts packages/indexer/src/frameworks/php/crudbooster/extract-flow.ts packages/indexer/src/languages/php/analyzer.ts packages/indexer/test/indexer.test.ts packages/query-engine/test/query-engine.test.ts
+git commit -m "Add CrudBooster graph extraction"
+```
+
+### Task 12: Harden generic query surfaces over PHP and Laravel facts
+
+**Files:**
+- Modify: `packages/query-engine/src/index.ts`
+- Modify: `packages/query-engine/test/query-engine.test.ts`
+- Modify: `packages/mcp/test/mcp.test.ts`
+- Modify: `packages/server/test/server.test.ts`
+- Modify: `packages/server/test/web-ui.test.ts`
+- Modify: `apps/web/src/workspace-screen.tsx`
+- Modify: `apps/web/src/workspace-focus-view-model.ts`
+- Modify: `apps/web/src/view-model.ts`
+- Modify: `apps/web/test/graph-first-workspace.spec.ts`
+- Modify: `playwright.config.ts`
+
+- [ ] **Step 1: Write failing tests for end-to-end PHP query surfaces**
+
+Add assertions covering:
+- `search` finds PHP classes and methods
+- `routes` lists Laravel routes
+- `impact` and `flow` operate on PHP facts without JS/TS assumptions
+- MCP and server responses surface PHP-derived graph data without shape changes
+- the graph-first workspace UI continues to prioritize graph and inspector flows
+  correctly when PHP or Laravel-backed results are present
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test packages/query-engine/test/query-engine.test.ts packages/mcp/test/mcp.test.ts packages/server/test/server.test.ts packages/server/test/web-ui.test.ts && pnpm exec playwright test apps/web/test/graph-first-workspace.spec.ts`
+Expected: FAIL if any consumer still assumes JS/TS-only language values or route
+patterns
+
+- [ ] **Step 3: Make minimal generic consumer fixes**
+
+Do not fork PHP behavior in multiple consumers unless strictly necessary. Prefer
+generic handling of shared graph facts and optional language labels only where
+display text needs them. If the workspace-focused UI needs adjustment, prefer
+fixes in `workspace-screen.tsx`, `workspace-focus-view-model.ts`, or shared
+workspace view-model helpers over ad hoc patches in tests.
+
+- [ ] **Step 4: Re-run tests to verify they pass**
+
+Run: `pnpm test packages/query-engine/test/query-engine.test.ts packages/mcp/test/mcp.test.ts packages/server/test/server.test.ts packages/server/test/web-ui.test.ts && pnpm exec playwright test apps/web/test/graph-first-workspace.spec.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/query-engine/src/index.ts packages/query-engine/test/query-engine.test.ts packages/mcp/test/mcp.test.ts packages/server/test/server.test.ts packages/server/test/web-ui.test.ts apps/web/src/workspace-screen.tsx apps/web/src/workspace-focus-view-model.ts apps/web/src/view-model.ts apps/web/test/graph-first-workspace.spec.ts playwright.config.ts
+git commit -m "Harden query surfaces for PHP frameworks"
+```
+
+## Final Verification Checklist
+
+- [ ] Run targeted indexer, query, MCP, server, and CLI tests after each chunk.
+- [ ] Run full workspace verification before closing the feature:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm exec playwright test apps/web/test/graph-first-workspace.spec.ts
+```
+
+Expected:
+- lint exits `0`
+- typecheck exits `0`
+- test exits `0`
+- Playwright graph-first workspace test exits `0`
+
+- [ ] Run manual smoke checks on GraphTrace CLI against:
+  - the GraphTrace repo itself
+  - `fixtures/laravel-workspace`
+  - `fixtures/crudbooster-legacy-workspace`
+
+Commands:
+
+```bash
+pnpm exec tsx packages/cli/src/bin.ts doctor --units
+pnpm exec tsx packages/cli/src/bin.ts doctor --plugins
+pnpm exec tsx packages/cli/src/bin.ts index --full --json
+pnpm exec tsx packages/cli/src/bin.ts routes
+pnpm exec tsx packages/cli/src/bin.ts search UserController --kind symbol
+```
+
+Expected:
+- PHP units appear with `language: "php"`
+- Laravel and CrudBooster plugin matches are explainable
+- route and symbol search return useful PHP results

--- a/docs/superpowers/plans/2026-05-28-graphtrace-mcp-reliability.md
+++ b/docs/superpowers/plans/2026-05-28-graphtrace-mcp-reliability.md
@@ -1,0 +1,278 @@
+# GraphTrace MCP Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make GraphTrace MCP reliable and useful enough for day-to-day agentic development across multi-workspace JS/TS and Laravel/PHP repos.
+
+**Architecture:** Fix the MCP/runtime layer first, then improve result ergonomics and coverage, then add feedback loops. Changes stay additive and backward-compatible: optional MCP inputs, new CLI subcommands, local-only telemetry, and minimal heuristic Laravel parsing.
+
+**Tech Stack:** TypeScript, Node.js, Vitest, Model Context Protocol SDK, GraphTrace CLI/MCP/server/indexer packages.
+
+---
+
+## File Map
+
+- `packages/mcp/src/index.ts` — MCP tool schemas, workspace resolution, symbol locator ergonomics, telemetry wrapper.
+- `packages/mcp/src/telemetry.ts` — local-only MCP telemetry writer.
+- `packages/mcp/test/mcp.test.ts` — MCP reliability regression tests.
+- `packages/cli/src/index.ts` — `agent doctor` and `analyze-sessions` commands.
+- `packages/cli/src/agent/doctor.ts` — agent/MCP config and version diagnostics.
+- `packages/cli/src/session-analysis.ts` — Codex session log analyzer.
+- `packages/cli/test/cli.test.ts` — CLI tests for new commands.
+- `packages/indexer/src/php-routes.ts` — minimal Laravel route extraction.
+- `packages/indexer/src/index.ts` — wire Laravel route extraction into indexing.
+- `packages/indexer/test/indexer.test.ts` — Laravel fixture regression.
+- `fixtures/laravel-workspace/routes/web.php` — route fixture.
+- `fixtures/laravel-workspace/app/Http/Controllers/UserController.php` — controller fixture.
+- `packages/*/CHANGELOG.md` — release notes.
+
+---
+
+### Task 1: P0 CLI Agent Doctor
+
+**Files:**
+- Create: `packages/cli/src/agent/doctor.ts`
+- Modify: `packages/cli/src/index.ts`
+- Test: `packages/cli/test/cli.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests near existing agent tests in `packages/cli/test/cli.test.ts`:
+
+```ts
+test("agent doctor reports versions, config, and workspace hints", async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), "graphtrace-cli-agent-doctor-"));
+  await writeFile(join(workspaceRoot, ".codex", "config.toml"), "[mcp_servers.graphtrace]\ncommand = \"graphtrace\"\nargs = [\"mcp\"]\n", "utf8").catch(async () => {
+    await mkdir(join(workspaceRoot, ".codex"), { recursive: true });
+    await writeFile(join(workspaceRoot, ".codex", "config.toml"), "[mcp_servers.graphtrace]\ncommand = \"graphtrace\"\nargs = [\"mcp\"]\n", "utf8");
+  });
+
+  const result = await runCli(["agent", "doctor"], { cwd: workspaceRoot });
+
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("GraphTrace Agent Doctor");
+  expect(result.stdout).toContain("cli_version:");
+  expect(result.stdout).toContain("workspace_root:");
+  expect(result.stdout).toContain("mcp_config:");
+  expect(result.stdout).toContain("recommendation:");
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `pnpm vitest run packages/cli/test/cli.test.ts -t "agent doctor reports"`
+Expected: FAIL because `agent doctor` is unknown.
+
+- [ ] **Step 3: Implement doctor**
+
+Create `packages/cli/src/agent/doctor.ts` with exported `inspectAgentDoctor()` and `formatAgentDoctorResult()` that report CLI version from package JSON, binary path from `process.argv[1]`, workspace root, GraphTrace home, and detected `.codex/config.toml` presence/content hints.
+
+- [ ] **Step 4: Wire CLI command**
+
+Modify `packages/cli/src/index.ts`:
+- Add `graphtrace agent doctor` help entry.
+- Import doctor helpers.
+- Add `case "doctor"` inside `case "agent"`.
+
+- [ ] **Step 5: Verify test passes**
+
+Run: `pnpm vitest run packages/cli/test/cli.test.ts -t "agent doctor reports"`
+Expected: PASS.
+
+---
+
+### Task 2: P0/P1 MCP Workspace Resolution
+
+**Files:**
+- Modify: `packages/mcp/src/index.ts`
+- Test: `packages/mcp/test/mcp.test.ts`
+
+- [ ] **Step 1: Write failing MCP tests**
+
+Add tests that cover:
+- MCP started from a repo matching one registered workspace selects that workspace even when multiple exist.
+- Ambiguous errors include candidate root paths and `list_workspaces` hint.
+- Invalid `/` workspaceRoot never attempts `/.graphtrace` and returns a helpful error.
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pnpm vitest run packages/mcp/test/mcp.test.ts -t "workspace"`
+Expected: at least one new test fails with old behavior.
+
+- [ ] **Step 3: Implement workspaceRoot inputs and cwd preference**
+
+Modify `WorkspaceResolutionHint` to include `workspaceRoot?: string`. Add `workspaceRoot` optional input to all MCP tools that currently accept `workspaceId`. Resolution priority:
+1. `workspaceId`
+2. `workspaceRoot`
+3. MCP startup cwd contained by exactly one registered workspace, choosing longest root match
+4. path hints from file/target/symbol
+5. single registered workspace
+6. legacy local DB
+7. helpful ambiguous error
+
+- [ ] **Step 4: Improve error copy**
+
+`ambiguousWorkspaceError()` must include id, label, canonicalRootPath, and `Hint: call list_workspaces`.
+
+- [ ] **Step 5: Verify MCP tests pass**
+
+Run: `pnpm vitest run packages/mcp/test/mcp.test.ts`
+Expected: PASS.
+
+---
+
+### Task 3: P2 Symbol API Ergonomics
+
+**Files:**
+- Modify: `packages/mcp/src/index.ts`
+- Test: `packages/mcp/test/mcp.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for:
+- `graphtrace_get_execution_context` with only `symbolName: "listUsers"` auto-resolves when one match exists.
+- Ambiguous `symbolName: "report"` returns structured candidates and hint instead of hard error.
+- `graphtrace_get_symbol_impact` supports same behavior.
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `pnpm vitest run packages/mcp/test/mcp.test.ts -t "symbolName"`
+Expected: FAIL with old `Expected symbolId...` error.
+
+- [ ] **Step 3: Implement symbol locator preparation**
+
+Add helper `resolveSymbolLocatorFromInput(engine, locator)` in `packages/mcp/src/index.ts`:
+- If `symbolId` or `filePath + symbolName` or `filePath + line + column`, keep existing behavior.
+- If `symbolName` only, call `engine.searchSymbols(symbolName)`.
+- If one match, return `{ symbolId }`.
+- If zero/multiple, return a tool result with `resolutionRequired: true`, `candidates`, and `hint`.
+
+- [ ] **Step 4: Verify symbol tests pass**
+
+Run: `pnpm vitest run packages/mcp/test/mcp.test.ts -t "symbolName"`
+Expected: PASS.
+
+---
+
+### Task 4: P2 Laravel Routes and Sparse Coverage
+
+**Files:**
+- Create: `packages/indexer/src/php-routes.ts`
+- Modify: `packages/indexer/src/index.ts`
+- Modify: `packages/shared/src/index.ts`
+- Test: `packages/indexer/test/indexer.test.ts`
+- Create: `fixtures/laravel-workspace/routes/web.php`
+- Create: `fixtures/laravel-workspace/app/Http/Controllers/UserController.php`
+- Create: `fixtures/laravel-workspace/composer.json`
+
+- [ ] **Step 1: Write failing Laravel indexer test**
+
+Add test asserting Laravel route fixture indexes at least `GET /users` with framework `laravel` and heuristic confidence.
+
+- [ ] **Step 2: Run failing test**
+
+Run: `pnpm vitest run packages/indexer/test/indexer.test.ts -t "laravel"`
+Expected: FAIL because Laravel routes are not indexed.
+
+- [ ] **Step 3: Implement minimal Laravel extraction**
+
+`extractLaravelRoutes(workspaceRoot)` reads `routes/*.php` and matches:
+- `Route::get('/users', [UserController::class, 'index'])`
+- `Route::post('/users', 'UserController@store')`
+- `Route::put`, `patch`, `delete`
+
+Return `RouteItem[]` with `framework: "laravel"`, `confidence: 0.65`, and provenance source `framework:laravel`.
+
+- [ ] **Step 4: Wire into indexer**
+
+When workspace has `composer.json`, `artisan`, or `routes/*.php`, append Laravel route items after JS/TS extraction.
+
+- [ ] **Step 5: Add coverage metadata minimally**
+
+Extend shared search/graph envelope types with optional `coverage`. Add coverage warning in query engine when selected units are `unknown`/`shallow`.
+
+- [ ] **Step 6: Verify Laravel test passes**
+
+Run: `pnpm vitest run packages/indexer/test/indexer.test.ts -t "laravel"`
+Expected: PASS.
+
+---
+
+### Task 5: P3 Telemetry and Session Analysis
+
+**Files:**
+- Create: `packages/mcp/src/telemetry.ts`
+- Modify: `packages/mcp/src/index.ts`
+- Create: `packages/cli/src/session-analysis.ts`
+- Modify: `packages/cli/src/index.ts`
+- Test: `packages/cli/test/cli.test.ts`
+- Test: `packages/mcp/test/mcp.test.ts`
+
+- [ ] **Step 1: Write failing CLI session-analysis test**
+
+Create temp JSONL session with one `mcp_tool_call_end` error and one GraphTrace → `rg` fallback message. Assert `graphtrace analyze-sessions <dir>` reports calls, errors, and fallback.
+
+- [ ] **Step 2: Implement session analyzer**
+
+Parse `.jsonl` recursively and count:
+- `mcp_tool_call_end` where `invocation.server === "graphtrace"`
+- errors where result `Ok.isError === true`
+- top first-line errors
+- fallback messages containing GraphTrace then `rg|grep|sed|đọc code|fallback`
+
+- [ ] **Step 3: Implement opt-in telemetry**
+
+`packages/mcp/src/telemetry.ts` writes NDJSON only if `GRAPHTRACE_MCP_TELEMETRY=1`. Wrap MCP handlers to record tool name, duration, success/error/empty, result size.
+
+- [ ] **Step 4: Verify CLI and MCP tests pass**
+
+Run: `pnpm vitest run packages/cli/test/cli.test.ts packages/mcp/test/mcp.test.ts`
+Expected: PASS.
+
+---
+
+### Task 6: Release Readiness
+
+**Files:**
+- Modify: `packages/cli/CHANGELOG.md`
+- Modify: `packages/mcp/CHANGELOG.md`
+- Modify: `packages/indexer/CHANGELOG.md`
+- Modify: `packages/shared/CHANGELOG.md` if shared types change
+- Modify: root/package version files via changeset/version tooling
+
+- [ ] **Step 1: Run targeted tests**
+
+Run:
+```bash
+pnpm vitest run packages/cli/test/cli.test.ts packages/mcp/test/mcp.test.ts packages/indexer/test/indexer.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 2: Run full validation**
+
+Run:
+```bash
+pnpm test
+pnpm typecheck
+pnpm build
+```
+Expected: PASS.
+
+- [ ] **Step 3: Update release notes**
+
+Add changelog bullets for P0-P3.
+
+- [ ] **Step 4: Publish**
+
+Run:
+```bash
+pnpm changeset
+pnpm release:version
+pnpm build
+npm publish --workspace packages/cli --access public
+```
+Expected: `graphtrace@1.7.0` published.
+
+- [ ] **Step 5: Close issues**
+
+Comment on #57-#60 with verification evidence and npm version, then close them.

--- a/docs/superpowers/specs/2026-04-12-php-laravel-crudbooster-design.md
+++ b/docs/superpowers/specs/2026-04-12-php-laravel-crudbooster-design.md
@@ -1,0 +1,465 @@
+# PHP, Laravel, and CrudBooster Design
+
+Date: 2026-04-12
+
+## Summary
+
+GraphTrace should evolve from a JS/TS-only indexer into a language-aware graph
+engine that can deeply analyze PHP repositories, with Laravel as the first
+framework target and CrudBooster as a Laravel-specialized layer.
+
+The immediate product goal is not perfect PHP static analysis. The goal is a
+usable repository graph that helps developers and AI agents answer practical
+questions in Laravel-heavy codebases:
+
+- which PHP units exist in this workspace
+- which routes map to which controllers or actions
+- which services, models, queries, and framework entrypoints a change may affect
+- how CrudBooster-generated or convention-driven modules fit into that graph
+
+This design keeps GraphTrace's existing query, MCP, server, and web surfaces as
+stable as possible by extending normalized facts rather than inventing a second
+backend for PHP.
+
+## Problem
+
+Today GraphTrace is structurally biased toward TypeScript and JavaScript:
+
+- workspace detection only deep-indexes `language === "js-ts"`
+- the indexer constructs a TypeScript program as the root analysis primitive
+- symbol extraction, references, and execution flow are all AST logic built on
+  the TypeScript compiler API
+- framework detection is implemented through heuristics directly in the current
+  indexer flow
+
+This creates three concrete blockers for PHP, Laravel, and CrudBooster support:
+
+1. PHP cannot become a first-class indexed language because it is currently
+   collapsed into `unknown`.
+2. Laravel support cannot be added cleanly without mixing more framework logic
+   into the JS/TS-centric core.
+3. CrudBooster support would be fragile if built on top of current framework
+   detection because the detector already produces false positives in mixed or
+   tooling-heavy repositories.
+
+Self-host analysis of the GraphTrace repository exposed the same structural
+issues:
+
+- the workspace root can degrade to `unknown` because of unrelated non-JS
+  markers in fixtures
+- framework matching can fire on internal source code that merely contains
+  detector strings, not on actual app usage
+
+Those two issues must be addressed before Laravel and CrudBooster support can be
+trusted.
+
+## Goals
+
+- Make PHP a first-class language in workspace discovery, indexing, and graph
+  output.
+- Support mixed-language repositories without collapsing the root workspace into
+  an unhelpful `unknown` bucket.
+- Support Laravel route, controller, model, service, and query graphing well
+  enough for `search`, `routes`, `impact`, and `flow` to be practically useful.
+- Add CrudBooster-aware extraction as a specialized layer on top of Laravel.
+- Preserve the current GraphTrace data model shape wherever possible so CLI,
+  MCP, server, and web consumers can reuse existing contracts.
+- Refactor the indexer enough to support multiple languages cleanly without
+  requiring a full external plugin system in this milestone.
+
+## Non-Goals
+
+- Building a fully precise whole-program PHP analyzer.
+- Solving every dynamic Laravel container or facade indirection in v1.
+- Deep Blade, Livewire, or frontend template graphing in v1.
+- Shipping a general external plugin runtime for third parties in this phase.
+- Depending on proprietary CrudBooster source code that cannot live in this
+  repository.
+
+## Scope
+
+### Required v1 outcomes
+
+- `graphtrace doctor --units --plugins` recognizes PHP units and Laravel or
+  CrudBooster matches.
+- `graphtrace routes` returns Laravel routes from common conventions and
+  resource-route helpers.
+- `graphtrace search --kind symbol` finds PHP classes and methods with stable
+  identities.
+- `graphtrace flow` can traverse common Laravel paths such as route ->
+  controller action -> service/model/query.
+- `graphtrace impact` returns useful file and symbol impact for ordinary Laravel
+  classes and methods.
+
+### Deferred outcomes
+
+- Perfect service-container resolution.
+- Full event bus, queue, and broadcast semantic modeling.
+- Exact support for all proprietary CrudBooster internals without a real sample
+  repository.
+
+## Design Principles
+
+- First-class language support beats one-off heuristics.
+- Practical graph utility beats semantic perfection.
+- Mixed-language workspaces must remain explainable.
+- Framework matches must be stricter and less noisy than they are today.
+- Core graph facts stay normalized so one query engine can serve all languages.
+- Language and framework logic should move behind internal capability boundaries
+  even if the runtime remains first-party and in-repo.
+
+## Architecture Direction
+
+GraphTrace should adopt an internal capability-oriented indexer rather than
+continuing to grow a single JS/TS-centric pipeline.
+
+### Core orchestration
+
+`packages/indexer/src/index.ts` should become an orchestrator that:
+
+- inspects workspace units
+- chooses the correct language analyzer per unit
+- runs framework matchers for that language
+- runs framework-specific extractors
+- merges normalized facts
+- persists facts through the existing graph store
+
+### Capability groups
+
+The internal boundaries should be:
+
+- workspace detector
+- language analyzer
+- framework matcher
+- fact extractor
+- linker or enricher
+
+This is intentionally aligned with the existing plugin architecture design doc,
+but without requiring runtime external plugin loading.
+
+### Language-specific modules
+
+The indexer should split into language and framework folders:
+
+- `packages/indexer/src/languages/js-ts/*`
+- `packages/indexer/src/languages/php/*`
+- `packages/indexer/src/frameworks/js/*`
+- `packages/indexer/src/frameworks/php/laravel/*`
+- `packages/indexer/src/frameworks/php/crudbooster/*`
+
+The existing JS/TS code paths should be moved into the JS/TS subtree with
+minimal behavioral changes first. PHP should then be added as a parallel path.
+
+## Workspace and Unit Model
+
+The current unit model is close to usable and should be extended rather than
+replaced.
+
+### Required type changes
+
+- `UnitLanguage` must support `php`.
+- symbol language metadata must support `php`.
+- unit plugin matches must be able to record `language:php`,
+  `framework:laravel`, and `framework:crudbooster`.
+
+### Discovery improvements
+
+Workspace discovery should:
+
+- score PHP markers separately from JS/TS markers
+- avoid downgrading a workspace root to `unknown` merely because unrelated
+  nested markers exist
+- allow a workspace to contain both `js-ts` and `php` full-index units
+- treat `composer.json`, `artisan`, `bootstrap/app.php`, `routes/*.php`, and
+  `app/**/*.php` as strong Laravel signals
+
+### Framework detection improvements
+
+Framework detection should stop relying so heavily on generic source-string
+matches. Stronger signals should come from:
+
+- Composer dependencies
+- Laravel file layout markers
+- bootstrapping files
+- route registration patterns
+- CrudBooster-specific namespaces, directories, base classes, or generated
+  module conventions
+
+## Parser Strategy
+
+The recommended PHP parser for v1 is `php-parser` on Node.
+
+Reasons:
+
+- fits the existing TypeScript and Node monorepo
+- avoids native build complexity in CLI and watch flows
+- good enough to support static AST extraction for class, method, namespace,
+  import, and common call patterns
+- can be hidden behind a small AST adapter so GraphTrace can swap to
+  `tree-sitter-php` later if incremental parsing or performance becomes a
+  priority
+
+GraphTrace should not expose the parser choice as a user-facing abstraction in
+this phase.
+
+## PHP Semantic Model
+
+### Symbol coverage
+
+PHP symbol extraction should include:
+
+- namespaces
+- classes
+- interfaces
+- traits
+- enums
+- top-level functions
+- class methods
+- important class constants and properties when useful for references
+
+Stable symbol IDs should follow the same broad philosophy as current symbol IDs:
+
+- file path
+- symbol local name or owner-qualified name
+
+For PHP this means typical IDs like:
+
+- `symbol:app/Http/Controllers/UserController.php#UserController`
+- `symbol:app/Http/Controllers/UserController.php#UserController.index`
+- `symbol:app/Models/User.php#User`
+
+### Reference and dependency coverage
+
+PHP extraction should emit useful edges from:
+
+- `use` imports
+- `extends`
+- `implements`
+- trait inclusion
+- `new ClassName(...)`
+- static calls like `Foo::bar()`
+- method parameter type hints
+- return type hints
+- obvious intra-file method calls on `$this`
+
+The v1 objective is a practical graph, not complete interprocedural precision.
+
+### Query coverage
+
+Query hint extraction should target:
+
+- Eloquent chains such as `User::query()->where(...)->get()`
+- common Eloquent shortcuts like `find`, `findOrFail`, `first`, `firstOrFail`,
+  `create`, `update`, `delete`
+- DB facade calls
+- query builder chains
+- raw SQL helpers where clearly detectable
+
+## Laravel Semantic Model
+
+### Framework detection
+
+Laravel should match when a unit has a meaningful combination of:
+
+- Composer dependency on `laravel/framework` or `illuminate/*`
+- `artisan`
+- `bootstrap/app.php`
+- `routes/web.php`, `routes/api.php`, or equivalent route files
+- `app/Http/Controllers`
+
+### Route extraction
+
+Laravel route extraction should support:
+
+- explicit `Route::get/post/put/patch/delete/options`
+- `match` and `any`
+- grouped routes with `prefix`, `name`, `middleware`, and `controller`
+- controller routes declared as arrays or string actions
+- invokable controllers
+- closure handlers
+- `resource`, `resources`, `apiResource`, `apiResources`
+- `singleton` and `apiSingleton`
+
+The extracted route fact format should stay aligned with the existing route
+model:
+
+- route ID
+- method
+- path
+- handler name
+- handler symbol ID
+- file path
+- framework
+- unit ID
+- confidence
+
+### Flow extraction
+
+Laravel execution flow should connect:
+
+- route to controller action
+- controller action to service class or method when statically visible
+- controller action to model or query hints
+- route parameters to action type hints when implicit model binding is obvious
+
+The graph should prefer conservative proven edges and allow inferred edges only
+when the evidence is clear enough to explain.
+
+### Optional route-list enrichment
+
+GraphTrace may later add optional enrichment from `php artisan route:list` when
+the command is available in a local workspace, but this must remain optional.
+Static extraction must stand on its own because CLI command execution is not
+always safe, cheap, or deterministic.
+
+## CrudBooster Semantic Model
+
+CrudBooster should be modeled as a Laravel-specialized framework layer rather
+than a separate language.
+
+### Two support modes
+
+#### `crudbooster-legacy`
+
+Targets public and archived OSS conventions such as:
+
+- `CBController` inheritance
+- `cbInit` configuration methods
+- CRUD-oriented admin module controllers
+- generated module conventions visible from source structure
+
+#### `crudbooster-modern`
+
+Targets public-site conventions and user-supplied sample repositories for newer
+versions, including:
+
+- `app/Cb/Modules/*`
+- `app/Cb/Types/*`
+- custom type registration
+- generated module structures
+- API builder or admin module conventions that can be seen from source
+
+Because the modern product is not fully public source, GraphTrace should treat
+this mode as convention-driven and sample-driven support, not a completeness
+guarantee.
+
+### Facts to extract
+
+CrudBooster extraction should produce:
+
+- module/controller discovery
+- module-to-controller relationships
+- module-to-model relationships when visible
+- generated admin route patterns where recoverable
+- CRUD lifecycle method symbols where conventional names exist
+
+## Graph Model Impact
+
+The core graph store and query engine should stay normalized.
+
+No new parallel PHP-only database model should be created.
+
+The existing entities remain sufficient with type extensions:
+
+- units
+- files
+- symbols
+- routes
+- edges
+- query hints
+
+The main changes are:
+
+- broader language enums
+- broader framework provenance
+- broader symbol extraction coverage
+
+## CLI, MCP, Server, and Web Impact
+
+The preferred path is compatibility-first.
+
+### CLI
+
+`doctor`, `index`, `status`, `search`, `routes`, `deps`, `impact`, and `flow`
+should continue to work without mandatory new flags.
+
+Possible later additions:
+
+- `--language`
+- `--framework`
+
+These should be optional filters, not required for PHP support.
+
+### MCP
+
+Existing MCP tools should benefit automatically once PHP facts are indexed into
+the shared graph model.
+
+### Server and Web UI
+
+The current server and UI layers should require only minimal changes if they
+already render generic route, file, and symbol facts.
+
+The biggest benefit should come from better indexed data, not a rewritten UI.
+
+However, the current `main` branch now uses a graph-first workspace UI with
+dedicated workspace presentation and Playwright coverage. PHP support should
+therefore be verified against the workspace-focused UI flow as it exists today,
+not only against server-side or view-model-only tests.
+
+## Rollout Strategy
+
+### Phase 0
+
+- Fix mixed-language workspace detection and current framework false positives.
+
+### Phase 1
+
+- Refactor the current JS/TS indexer into internal capability boundaries.
+
+### Phase 2
+
+- Add PHP language support with symbol, import/reference, and query extraction.
+
+### Phase 3
+
+- Add Laravel route and controller flow extraction.
+
+### Phase 4
+
+- Add CrudBooster extraction and sample-driven hardening.
+
+### Phase 5
+
+- Harden query, MCP, server, and web behaviors over the new PHP facts.
+
+## Risks
+
+- Laravel route configuration can be highly dynamic.
+- Container and facade magic can hide real dependencies.
+- CrudBooster modern coverage may stall without a real sample repository.
+- PHP support may worsen false positives if framework detection is not tightened
+  first.
+- Watch mode and snapshot logic currently assume JS/TS file extensions and will
+  silently miss PHP unless explicitly updated.
+
+## Mitigations
+
+- Keep the graph conservative and evidence-based.
+- Use fixture-driven coverage for ordinary Laravel patterns before unusual ones.
+- Support optional enrichment later, but do not depend on runtime shelling out.
+- Land Phase 0 detection cleanup before broad PHP extraction.
+- Add fixture workspaces for basic PHP, Laravel, and CrudBooster patterns.
+
+## Acceptance Criteria
+
+- GraphTrace recognizes PHP units as first-class units instead of `unknown`.
+- Mixed workspaces with JS/TS and PHP remain explainable in `doctor --units`.
+- Laravel route extraction works for common route conventions and resource
+  helpers.
+- PHP class and method symbols appear in search and can participate in impact
+  and flow output.
+- Query hints capture useful Eloquent and DB access patterns.
+- CrudBooster repositories gain usable module and controller graph coverage from
+  source conventions.
+- Existing JS/TS behavior remains intact after the internal refactor.

--- a/docs/superpowers/specs/2026-05-28-graphtrace-mcp-reliability-design.md
+++ b/docs/superpowers/specs/2026-05-28-graphtrace-mcp-reliability-design.md
@@ -1,0 +1,440 @@
+# GraphTrace MCP Reliability & Coverage Improvement
+
+**Date:** 2026-05-28  
+**Status:** Draft  
+**Priority:** P0-P3 (phased rollout)
+
+## Context
+
+GraphTrace MCP hiện đang gặp vấn đề tin cậy và coverage khiến agent thường fallback sang `rg`/đọc file thay vì dùng graph data. Phân tích 37 session Codex cho thấy:
+
+- 606 MCP tool calls, 45 errors (7.4% error rate)
+- Lỗi chính: DB bootstrap fail, workspace ambiguous, version drift, sparse results cho non-JS
+- Agent pattern: thử GraphTrace → fail/sparse → fallback `rg` → mất niềm tin
+
+## Goals
+
+1. **P0:** Ổn định runtime - zero DB bootstrap errors, version/schema consistency
+2. **P1:** Workspace UX - zero ambiguous errors, explicit workspace selection
+3. **P2:** Reduce friction - symbol API flexible, sparse results actionable
+4. **P3:** Quality feedback - telemetry, regression suite từ real sessions
+
+## Non-Goals
+
+- Không làm lại indexer core
+- Không support thêm language mới ngoài PHP/Laravel minimal
+- Không thay đổi CLI interface hiện tại
+
+## Design
+
+### P0: Runtime Stability
+
+**Problem:**
+- Global `graphtrace@1.5.2` vs repo `1.6.2` → schema mismatch
+- MCP cố tạo `/.graphtrace` khi `workspaceRoot` undefined
+- `unable to open database file` khi DB path sai
+
+**Solution:**
+
+1. **Version doctor command:**
+```bash
+graphtrace agent doctor
+```
+Output:
+```
+GraphTrace Agent Doctor
+=======================
+CLI version: 1.6.2
+Global binary: /opt/homebrew/bin/graphtrace
+MCP schema version: 1.6.2
+Active MCP config: /Users/.../config.toml
+  - command: graphtrace
+  - args: ["mcp"]
+  - cwd: /Users/.../GraphTrace
+  - home: /Users/.../.graphtrace
+
+Workspace resolution:
+  - Current cwd: /Users/.../GraphTrace
+  - Registered workspaces: 8
+  - Auto-selected: graphtrace-44987867 (GraphTrace)
+  - Status: ✓ index fresh (2026-05-27)
+
+Issues:
+  ⚠ Global binary version (1.5.2) != repo version (1.6.2)
+  → Run: npm install -g graphtrace@latest
+```
+
+2. **MCP bootstrap safety:**
+```typescript
+// packages/mcp/src/index.ts
+function resolveWorkspaceContext(hint: WorkspaceResolutionHint): ResolvedWorkspaceContext {
+  const homeDir = options.homeDir ?? homedir();
+  const workspaceRoot = options.workspaceRoot;
+  
+  // NEVER create /.graphtrace
+  if (!workspaceRoot || workspaceRoot === '/') {
+    throw new Error(
+      `GraphTrace MCP requires valid workspaceRoot. Got: ${workspaceRoot}. ` +
+      `Check MCP config 'cwd' or pass --home flag.`
+    );
+  }
+  
+  // ... rest
+}
+```
+
+3. **Config validation:**
+```toml
+# .codex/config.toml
+[mcp_servers.graphtrace]
+command = "graphtrace"
+args = ["mcp", "--home", "/Users/tuannguyen8888/.graphtrace"]
+# Optional: pin to local build
+# command = "/Users/.../GraphTrace/packages/cli/dist/bin.js"
+```
+
+**Acceptance:**
+- `graphtrace agent doctor` shows version, config, workspace state
+- Zero `/.graphtrace` errors
+- Zero `unable to open database` errors when workspace valid
+
+---
+
+### P1: Workspace Resolution UX
+
+**Problem:**
+- `get_status` fails với "could not resolve workspace" nhưng không trả candidates
+- Agent không biết cần pass `workspaceId`
+- MCP auto-select workspace sai (chọn `telecodex` khi đang ở repo `GraphTrace`)
+
+**Solution:**
+
+1. **Explicit workspace in all tools:**
+```typescript
+// All MCP tools accept optional workspaceId
+server.registerTool("get_status", {
+  inputSchema: {
+    workspaceId: z.string().optional(),
+    workspaceRoot: z.string().optional(), // fallback for legacy
+  }
+}, async ({ workspaceId, workspaceRoot }) => {
+  // ...
+});
+```
+
+2. **Better error messages:**
+```typescript
+function ambiguousWorkspaceError(workspaces: WorkspaceRecord[]): Error {
+  const candidates = workspaces.map(w => 
+    `  - ${w.id} (${w.label}) at ${w.canonicalRootPath}`
+  ).join('\n');
+  
+  return new Error(
+    `GraphTrace MCP could not resolve workspace automatically.\n` +
+    `Pass workspaceId or workspaceRoot explicitly.\n\n` +
+    `Registered workspaces:\n${candidates}\n\n` +
+    `Hint: Use list_workspaces tool to see all options.`
+  );
+}
+```
+
+3. **Smarter auto-selection:**
+```typescript
+function resolveWorkspaceContext(hint: WorkspaceResolutionHint): ResolvedWorkspaceContext {
+  // Priority:
+  // 1. Explicit workspaceId
+  // 2. Explicit workspaceRoot
+  // 3. Match cwd against registered workspaces
+  // 4. Single registered workspace
+  // 5. Legacy local .graphtrace/index.db
+  // 6. Error with candidates
+  
+  if (hint.workspaceId) {
+    return getById(hint.workspaceId);
+  }
+  
+  if (hint.workspaceRoot) {
+    return getByRoot(hint.workspaceRoot);
+  }
+  
+  const cwd = options.workspaceRoot; // from MCP startup
+  const matchingByCwd = registeredWorkspaces.filter(w => 
+    cwd.startsWith(w.canonicalRootPath)
+  );
+  
+  if (matchingByCwd.length === 1) {
+    return matchingByCwd[0];
+  }
+  
+  // ... rest
+}
+```
+
+**Acceptance:**
+- Zero ambiguous errors without helpful message
+- `get_status` without args works when cwd matches exactly one workspace
+- Error messages include `list_workspaces` hint
+
+---
+
+### P2: Reduce Friction
+
+**Problem:**
+- `graphtrace_get_execution_context` requires `filePath + symbolName` but agent often only has `symbolName`
+- Laravel/PHP repos return sparse/empty results
+- Agent không biết khi nào nên fallback
+
+**Solution:**
+
+1. **Flexible symbol locator:**
+```typescript
+server.registerTool("graphtrace_get_execution_context", {
+  inputSchema: {
+    workspaceId: z.string().optional(),
+    // Accept any of:
+    symbolId: z.string().optional(),
+    symbolName: z.string().optional(), // search first if alone
+    filePath: z.string().optional(),
+    line: z.number().optional(),
+    column: z.number().optional(),
+  }
+}, async (args) => {
+  if (args.symbolName && !args.filePath && !args.symbolId) {
+    // Auto-search and disambiguate
+    const candidates = engine.searchSymbols(args.symbolName);
+    if (candidates.items.length === 0) {
+      return asToolResult({
+        error: `No symbol found matching "${args.symbolName}"`,
+        hint: "Try search_code or graphtrace_search_symbols first"
+      });
+    }
+    if (candidates.items.length === 1) {
+      args.symbolId = candidates.items[0].id;
+    } else {
+      return asToolResult({
+        error: `Multiple symbols match "${args.symbolName}"`,
+        candidates: candidates.items.slice(0, 5),
+        hint: "Pass symbolId or filePath to disambiguate"
+      });
+    }
+  }
+  // ... rest
+});
+```
+
+2. **Sparse result metadata:**
+```typescript
+interface GraphEnvelope {
+  items: Item[];
+  graph: Graph;
+  coverage?: {
+    language: string;
+    indexingMode: 'full' | 'shallow' | 'skipped';
+    warnings?: string[];
+    fallbackHints?: string[];
+  };
+}
+
+// Example for Laravel repo:
+{
+  items: [...],
+  coverage: {
+    language: 'unknown',
+    indexingMode: 'shallow',
+    warnings: [
+      'PHP/Laravel not fully indexed',
+      'Routes may be incomplete'
+    ],
+    fallbackHints: [
+      'Use rg "Route::" routes/ for route definitions',
+      'Use rg "class.*Controller" app/Http/Controllers for handlers'
+    ]
+  }
+}
+```
+
+3. **Minimal PHP/Laravel support:**
+```typescript
+// packages/indexer/src/php-routes.ts
+export function extractLaravelRoutes(
+  workspaceRoot: string,
+  routesDir: string
+): RouteItem[] {
+  // Parse routes/*.php for Route::get/post/...
+  // Extract controller@method
+  // Return RouteItem[] with framework: 'laravel'
+}
+
+// packages/indexer/src/index.ts
+if (matchedPluginIds.has('framework:laravel')) {
+  routes.push(...extractLaravelRoutes(workspaceRoot, 'routes'));
+}
+```
+
+**Acceptance:**
+- `graphtrace_get_execution_context` với chỉ `symbolName` trả candidates hoặc auto-resolve
+- Laravel repos trả `coverage.warnings` + `fallbackHints`
+- Laravel routes cơ bản được index (GET/POST path + controller)
+
+---
+
+### P3: Quality Feedback
+
+**Problem:**
+- Không biết tool nào fail nhiều
+- Không biết khi nào agent fallback sau GraphTrace
+- Không có regression suite cho MCP UX
+
+**Solution:**
+
+1. **MCP telemetry:**
+```typescript
+// packages/mcp/src/telemetry.ts
+interface McpCallLog {
+  timestamp: string;
+  tool: string;
+  args: Record<string, unknown>;
+  duration_ms: number;
+  status: 'success' | 'error' | 'empty';
+  error?: string;
+  result_size?: number;
+}
+
+// Log to ~/.graphtrace/mcp-telemetry.ndjson
+// Opt-in via env var GRAPHTRACE_MCP_TELEMETRY=1
+```
+
+2. **Session analysis tool:**
+```bash
+graphtrace analyze-sessions /Users/.../sessions/2026/05
+```
+Output:
+```
+GraphTrace MCP Session Analysis
+================================
+Period: 2026-05-01 to 2026-05-28
+Sessions: 37
+Total calls: 606
+Errors: 45 (7.4%)
+
+Top errors:
+  - unable to open database: 24
+  - workspace ambiguous: 12
+  - Expected symbolId: 4
+
+Tools with >10% error rate:
+  - get_status: 16/82 (19.5%)
+  - graphtrace_get_execution_context: 4/24 (16.7%)
+
+Fallback patterns:
+  - GraphTrace → rg: 89 occurrences
+  - GraphTrace → read file: 67 occurrences
+```
+
+3. **MCP integration tests:**
+```typescript
+// packages/mcp/test/mcp-reliability.test.ts
+describe('MCP reliability', () => {
+  test('get_status without workspaceId when single workspace', async () => {
+    // ...
+  });
+  
+  test('get_status with ambiguous workspaces returns candidates', async () => {
+    // ...
+  });
+  
+  test('graphtrace_get_execution_context with symbolName-only', async () => {
+    // ...
+  });
+  
+  test('Laravel repo returns coverage warnings', async () => {
+    // ...
+  });
+});
+```
+
+**Acceptance:**
+- Telemetry logs MCP calls khi opt-in
+- `graphtrace analyze-sessions` báo cáo error rate, fallback patterns
+- MCP test suite cover các issue đã gặp
+
+---
+
+## Implementation Plan
+
+### Phase 1: P0 (Week 1)
+1. Add `graphtrace agent doctor` command
+2. Fix MCP bootstrap validation (no `/.graphtrace`)
+3. Add version/schema checks
+4. Update global package to 1.6.2
+5. Test: zero bootstrap errors
+
+### Phase 2: P1 (Week 1-2)
+1. Add `workspaceId` to all MCP tools
+2. Improve workspace auto-selection logic
+3. Better error messages with candidates
+4. Update skill docs
+5. Test: zero ambiguous errors without hints
+
+### Phase 3: P2 (Week 2-3)
+1. Flexible symbol locator with auto-search
+2. Add `coverage` metadata to results
+3. Minimal Laravel route extraction
+4. Update MCP tests
+5. Test: Laravel repos usable, symbol API flexible
+
+### Phase 4: P3 (Week 3-4)
+1. Add MCP telemetry (opt-in)
+2. Build `analyze-sessions` tool
+3. MCP reliability test suite
+4. Documentation updates
+5. Test: telemetry working, analysis accurate
+
+### Phase 5: Release
+1. Run full test suite
+2. Update CHANGELOG.md
+3. Version bump to 1.7.0
+4. `npm publish`
+5. Create GitHub release
+6. Update global install: `npm install -g graphtrace@latest`
+
+---
+
+## Testing Strategy
+
+1. **Unit tests:** Each package has tests for new logic
+2. **Integration tests:** MCP test suite covers real scenarios
+3. **Manual testing:** Test against real Codex sessions
+4. **Regression:** Run against saved session logs
+
+---
+
+## Risks & Mitigations
+
+**Risk:** Breaking changes to MCP schema  
+**Mitigation:** All new params optional, backward compatible
+
+**Risk:** Laravel support incomplete  
+**Mitigation:** Start minimal (routes only), add coverage warnings
+
+**Risk:** Telemetry privacy concerns  
+**Mitigation:** Opt-in only, local storage, no network
+
+---
+
+## Success Metrics
+
+- MCP error rate < 2% (from 7.4%)
+- Agent fallback rate < 30% (from ~50%)
+- Laravel repos show coverage warnings
+- Zero version drift issues
+- `graphtrace agent doctor` used in troubleshooting
+
+---
+
+## Open Questions
+
+1. Should we auto-update global package on `graphtrace agent setup`?
+2. Should telemetry be on by default with opt-out?
+3. Should we add `graphtrace mcp --validate` to check config before starting?
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphtrace-workspace",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "private": true,
   "type": "module",
   "files": [

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,17 @@
 # graphtrace
 
+## 1.8.0
+
+### Minor Changes
+
+- Improve GraphTrace MCP reliability for agentic development workflows.
+
+  - Add `graphtrace agent doctor` and `graphtrace analyze-sessions` for diagnosing MCP setup, version drift, session errors, and fallback behavior.
+  - Make MCP workspace resolution prefer explicit `workspaceRoot` and startup cwd before requiring manual workspace ids.
+  - Improve symbol-name-only MCP lookups with disambiguation hints instead of empty graph results.
+  - Add partial-coverage warnings for shallow or unknown units in query results.
+  - Add opt-in local MCP telemetry via `GRAPHTRACE_MCP_TELEMETRY=1`.
+
 ## 1.7.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphtrace",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Local-first code graph for JS/TS and PHP projects with CLI, MCP, and local web UI.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/agent/doctor.ts
+++ b/packages/cli/src/agent/doctor.ts
@@ -1,0 +1,136 @@
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface AgentDoctorOptions {
+  binaryPath: string;
+  cliVersion: string;
+  graphTraceHome: string;
+  userHomeDir?: string;
+  workspaceRoot: string;
+}
+
+export interface AgentDoctorConfigStatus {
+  args: string[];
+  command: string | null;
+  exists: boolean;
+  path: string;
+  scope: "project" | "user";
+}
+
+export interface AgentDoctorReport {
+  binaryPath: string;
+  cliVersion: string;
+  configs: AgentDoctorConfigStatus[];
+  graphTraceHome: string;
+  recommendations: string[];
+  workspaceRoot: string;
+}
+
+export async function inspectAgentDoctor(
+  options: AgentDoctorOptions,
+): Promise<AgentDoctorReport> {
+  const userHomeDir = options.userHomeDir ?? homedir();
+  const configs = await Promise.all([
+    inspectConfig(
+      "project",
+      join(options.workspaceRoot, ".codex", "config.toml"),
+    ),
+    inspectConfig("user", join(userHomeDir, ".codex", "config.toml")),
+  ]);
+
+  return {
+    binaryPath: options.binaryPath,
+    cliVersion: options.cliVersion,
+    configs,
+    graphTraceHome: options.graphTraceHome,
+    recommendations: buildRecommendations(configs),
+    workspaceRoot: options.workspaceRoot,
+  };
+}
+
+export function formatAgentDoctorResult(report: AgentDoctorReport): string {
+  return [
+    "GraphTrace Agent Doctor",
+    `cli_version:${report.cliVersion}`,
+    `binary:${report.binaryPath}`,
+    `workspace_root:${report.workspaceRoot}`,
+    `graphtrace_home:${report.graphTraceHome}`,
+    ...report.configs.flatMap((config) => [
+      `mcp_config:${config.scope}:${config.exists ? "present" : "missing"}:${config.path}`,
+      `mcp_command:${config.scope}:${config.command ?? "unknown"}`,
+      `mcp_args:${config.scope}:${config.args.length > 0 ? config.args.join(" ") : "unknown"}`,
+    ]),
+    ...report.recommendations.map(
+      (recommendation) => `recommendation:${recommendation}`,
+    ),
+  ].join("\n");
+}
+
+async function inspectConfig(
+  scope: AgentDoctorConfigStatus["scope"],
+  path: string,
+): Promise<AgentDoctorConfigStatus> {
+  const content = await readOptionalFile(path);
+
+  return {
+    args: content ? readTomlStringArray(content, "args") : [],
+    command: content ? readTomlString(content, "command") : null,
+    exists: content !== null,
+    path,
+    scope,
+  };
+}
+
+function buildRecommendations(configs: AgentDoctorConfigStatus[]): string[] {
+  const presentConfigs = configs.filter((config) => config.exists);
+  if (presentConfigs.length === 0) {
+    return ["run graphtrace agent setup --tool codex before using MCP"];
+  }
+
+  const graphTraceConfigs = presentConfigs.filter(
+    (config) => config.command === "graphtrace",
+  );
+  if (graphTraceConfigs.length === 0) {
+    return ["configure mcp_servers.graphtrace command to use graphtrace"];
+  }
+
+  if (
+    graphTraceConfigs.some(
+      (config) =>
+        config.args.includes("mcp") && !config.args.includes("--home"),
+    )
+  ) {
+    return [
+      "include --home in graphtrace MCP args for stable shared workspace resolution",
+    ];
+  }
+
+  return [
+    "GraphTrace MCP config detected; run graphtrace status to verify the selected workspace",
+  ];
+}
+
+async function readOptionalFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function readTomlString(content: string, key: string): string | null {
+  const match = content.match(new RegExp(`^${key}\\s*=\\s*"([^"]*)"`, "m"));
+  return match?.[1] ?? null;
+}
+
+function readTomlStringArray(content: string, key: string): string[] {
+  const match = content.match(
+    new RegExp(`^${key}\\s*=\\s*\\[([^\\]]*)\\]`, "m"),
+  );
+  if (!match) {
+    return [];
+  }
+
+  return [...match[1].matchAll(/"([^"]*)"/g)].map((item) => item[1]);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -18,6 +18,7 @@ import {
   type SupportedAgentTool,
   planAgentBootstrap,
 } from "./agent/bootstrap";
+import { formatAgentDoctorResult, inspectAgentDoctor } from "./agent/doctor";
 import {
   type AgentSetupWriteMode,
   applyRenderedAgentFiles,
@@ -26,6 +27,10 @@ import {
 } from "./agent/files";
 import { inspectAgentBootstrapStatus } from "./agent/status";
 import { renderAgentBootstrapFiles } from "./agent/templates";
+import {
+  analyzeGraphTraceSessions,
+  formatSessionAnalysis,
+} from "./session-analysis";
 
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".php"]);
 const IGNORED_NAMES = new Set([
@@ -360,6 +365,13 @@ const CLI_HELP_TREE: CliHelpCommand = {
       notes: ["Run 'graphtrace workspace <subcommand> --help' for details."],
     },
     {
+      name: "analyze-sessions",
+      heading: "graphtrace analyze-sessions",
+      summary: "Summarize GraphTrace MCP usage from Codex JSONL sessions.",
+      usage: "graphtrace analyze-sessions <path>",
+      examples: ["graphtrace analyze-sessions ~/.codex/sessions"],
+    },
+    {
       name: "agent",
       heading: "graphtrace agent",
       summary:
@@ -462,10 +474,32 @@ const CLI_HELP_TREE: CliHelpCommand = {
             "graphtrace agent restore --scope user",
           ],
         },
+        {
+          name: "doctor",
+          heading: "graphtrace agent doctor",
+          summary: "Diagnose GraphTrace MCP agent runtime configuration.",
+          usage:
+            "graphtrace agent doctor [--scope <project|user>] [--home <path>]",
+          options: [
+            {
+              flags: "--scope <scope>",
+              description: "Inspect project-local or user-scoped integration.",
+            },
+            {
+              flags: "--home <path>",
+              description: "Override the GraphTrace home directory.",
+            },
+          ],
+          examples: [
+            "graphtrace agent doctor",
+            "graphtrace agent doctor --scope user",
+          ],
+        },
       ],
       examples: [
         "graphtrace agent setup --tool codex",
         "graphtrace agent status",
+        "graphtrace agent doctor",
         "graphtrace agent restore",
       ],
       notes: ["Run 'graphtrace agent <subcommand> --help' for details."],
@@ -654,6 +688,20 @@ export async function runCli(
             stderr: "",
           };
         }
+        case "doctor": {
+          const report = await inspectAgentDoctor({
+            binaryPath: process.argv[1] ?? "unknown",
+            cliVersion: await readCliVersion(),
+            graphTraceHome,
+            userHomeDir,
+            workspaceRoot: cwd,
+          });
+          return {
+            exitCode: 0,
+            stdout: formatAgentDoctorResult(report),
+            stderr: "",
+          };
+        }
         case "restore": {
           const state = await loadAgentSetupState(
             scope === "user" ? graphTraceHome : cwd,
@@ -688,6 +736,25 @@ export async function runCli(
             ),
           };
       }
+    }
+    case "analyze-sessions": {
+      const targetPath = args[0];
+      if (!targetPath) {
+        return {
+          exitCode: 1,
+          stdout: "",
+          stderr: "analyze-sessions requires a JSONL file or directory path",
+        };
+      }
+
+      const summary = await analyzeGraphTraceSessions(
+        resolveWorkspaceArg(cwd, targetPath),
+      );
+      return {
+        exitCode: 0,
+        stdout: formatSessionAnalysis(summary),
+        stderr: "",
+      };
     }
     case "index": {
       const { runWorkspaceIndex } = await loadQueryEngineModule();

--- a/packages/cli/src/session-analysis.ts
+++ b/packages/cli/src/session-analysis.ts
@@ -1,0 +1,214 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+export interface SessionAnalysisSummary {
+  files: number;
+  graphtraceCalls: number;
+  graphtraceErrors: number;
+  fallbackMentions: number;
+  toolCounts: Record<string, { calls: number; errors: number }>;
+  topErrors: Array<{ message: string; count: number }>;
+}
+
+export async function analyzeGraphTraceSessions(
+  targetPath: string,
+): Promise<SessionAnalysisSummary> {
+  const files = await listJsonlFiles(resolve(targetPath));
+  const summary: SessionAnalysisSummary = {
+    files: files.length,
+    graphtraceCalls: 0,
+    graphtraceErrors: 0,
+    fallbackMentions: 0,
+    toolCounts: {},
+    topErrors: [],
+  };
+  const errors = new Map<string, number>();
+
+  for (const filePath of files) {
+    const lines = (await readFile(filePath, "utf8")).split(/\r?\n/);
+    for (const line of lines) {
+      if (!line.trim()) {
+        continue;
+      }
+
+      const event = parseJsonLine(line);
+      if (!event) {
+        continue;
+      }
+
+      if (isFallbackMention(event)) {
+        summary.fallbackMentions += 1;
+      }
+
+      const call = readGraphTraceMcpCall(event);
+      if (!call) {
+        continue;
+      }
+
+      summary.graphtraceCalls += 1;
+      if (!summary.toolCounts[call.toolName]) {
+        summary.toolCounts[call.toolName] = {
+          calls: 0,
+          errors: 0,
+        };
+      }
+      const tool = summary.toolCounts[call.toolName];
+      tool.calls += 1;
+
+      if (call.isError) {
+        summary.graphtraceErrors += 1;
+        tool.errors += 1;
+        const message = firstLine(call.errorMessage || "unknown error");
+        errors.set(message, (errors.get(message) ?? 0) + 1);
+      }
+    }
+  }
+
+  summary.topErrors = [...errors]
+    .map(([message, count]) => ({ message, count }))
+    .sort(
+      (left, right) =>
+        right.count - left.count || left.message.localeCompare(right.message),
+    )
+    .slice(0, 10);
+
+  return summary;
+}
+
+export function formatSessionAnalysis(summary: SessionAnalysisSummary): string {
+  const lines = [
+    "GraphTrace Session Analysis",
+    `files:${summary.files}`,
+    `graphtrace_calls:${summary.graphtraceCalls}`,
+    `graphtrace_errors:${summary.graphtraceErrors}`,
+    `fallback_mentions:${summary.fallbackMentions}`,
+  ];
+
+  const tools = Object.entries(summary.toolCounts).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  if (tools.length > 0) {
+    lines.push("tools:");
+    for (const [toolName, counts] of tools) {
+      lines.push(
+        `- ${toolName}: calls=${counts.calls} errors=${counts.errors}`,
+      );
+    }
+  }
+
+  if (summary.topErrors.length > 0) {
+    lines.push("top_errors:");
+    for (const error of summary.topErrors) {
+      lines.push(`- ${error.message} (${error.count})`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function listJsonlFiles(targetPath: string): Promise<string[]> {
+  const targetStats = await stat(targetPath);
+  if (targetStats.isFile()) {
+    return targetPath.endsWith(".jsonl") ? [targetPath] : [];
+  }
+
+  const entries = await readdir(targetPath, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map((entry) => {
+      const entryPath = join(targetPath, entry.name);
+      return entry.isDirectory()
+        ? listJsonlFiles(entryPath)
+        : Promise.resolve(entry.name.endsWith(".jsonl") ? [entryPath] : []);
+    }),
+  );
+  return nested.flat().sort();
+}
+
+function parseJsonLine(line: string): unknown | null {
+  try {
+    return JSON.parse(line) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function readGraphTraceMcpCall(event: unknown): {
+  toolName: string;
+  isError: boolean;
+  errorMessage: string;
+} | null {
+  const record = asRecord(event);
+  if (!record) {
+    return null;
+  }
+
+  const invocation = asRecord(record.invocation) ?? asRecord(record.tool_call);
+  const server = readString(invocation?.server ?? record.server);
+  if (server !== "graphtrace") {
+    return null;
+  }
+
+  const toolName =
+    readString(invocation?.tool ?? invocation?.toolName ?? record.tool) ??
+    "unknown";
+  const result = asRecord(record.result);
+  const okResult = asRecord(result?.Ok ?? result?.ok);
+  const isError = Boolean(
+    okResult?.isError ?? result?.isError ?? record.isError,
+  );
+  const errorMessage = collectStrings(result ?? record)
+    .filter((text) => text !== "graphtrace" && text !== toolName)
+    .join(" ")
+    .trim();
+
+  return {
+    toolName,
+    isError,
+    errorMessage,
+  };
+}
+
+function isFallbackMention(event: unknown): boolean {
+  const text = collectStrings(event).join("\n").toLowerCase();
+  return (
+    text.includes("graphtrace") &&
+    (text.includes("fallback") ||
+      text.includes("falling back") ||
+      text.includes("ripgrep") ||
+      /\brg\b/.test(text))
+  );
+}
+
+function collectStrings(value: unknown, output: string[] = []): string[] {
+  if (typeof value === "string") {
+    output.push(value);
+    return output;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectStrings(item, output);
+    }
+    return output;
+  }
+  const record = asRecord(value);
+  if (record) {
+    for (const nested of Object.values(record)) {
+      collectStrings(nested, output);
+    }
+  }
+  return output;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function firstLine(value: string): string {
+  return value.split(/\r?\n/)[0]?.trim() || "unknown error";
+}

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -216,6 +216,53 @@ describe("cli", () => {
     );
   });
 
+  test("analyze-sessions summarizes GraphTrace MCP errors and fallbacks", async () => {
+    const sessionsRoot = await mkdtemp(
+      join(tmpdir(), "graphtrace-cli-sessions-"),
+    );
+    await writeFile(
+      join(sessionsRoot, "session.jsonl"),
+      [
+        JSON.stringify({
+          type: "mcp_tool_call_end",
+          invocation: { server: "graphtrace", tool: "get_status" },
+          result: { Ok: { isError: false } },
+        }),
+        JSON.stringify({
+          type: "mcp_tool_call_end",
+          invocation: { server: "graphtrace", tool: "get_routes" },
+          result: {
+            Ok: {
+              isError: true,
+              content: [{ text: "unable to open database file" }],
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "response_item",
+          item: {
+            type: "message",
+            content: [
+              { text: "GraphTrace failed, falling back to rg for routes" },
+            ],
+          },
+        }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await runCli(["analyze-sessions", sessionsRoot], {
+      cwd: process.cwd(),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("GraphTrace Session Analysis");
+    expect(result.stdout).toContain("graphtrace_calls:2");
+    expect(result.stdout).toContain("graphtrace_errors:1");
+    expect(result.stdout).toContain("fallback_mentions:1");
+    expect(result.stdout).toContain("unable to open database file");
+  });
+
   test("process --help prints top-level CLI help", async () => {
     const result = await runCliProcess(process.cwd(), ["--help"]);
 
@@ -574,6 +621,28 @@ describe("cli", () => {
         }),
       ]),
     );
+  });
+
+  test("agent doctor reports versions, config, and workspace hints", async () => {
+    const workspaceRoot = await mkdtemp(
+      join(tmpdir(), "graphtrace-cli-agent-doctor-"),
+    );
+    await mkdir(join(workspaceRoot, ".codex"), { recursive: true });
+    await writeFile(
+      join(workspaceRoot, ".codex", "config.toml"),
+      '[mcp_servers.graphtrace]\ncommand = "graphtrace"\nargs = ["mcp"]\n',
+      "utf8",
+    );
+
+    const result = await runCli(["agent", "doctor"], { cwd: workspaceRoot });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("GraphTrace Agent Doctor");
+    expect(result.stdout).toContain("cli_version:");
+    expect(result.stdout).toContain("workspace_root:");
+    expect(result.stdout).toContain("mcp_config:");
+    expect(result.stdout).toContain("recommendation:");
+    expect(result.stderr).toBe("");
   });
 
   test("agent restore removes created files and restores overwritten content", async () => {

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphtrace/config
 
+## 1.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @graphtrace/shared@1.8.0
+
 ## 1.7.2
 
 ### Patch Changes

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/config",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/indexer/CHANGELOG.md
+++ b/packages/indexer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphtrace/indexer
 
+## 1.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @graphtrace/shared@1.8.0
+
 ## 1.7.2
 
 ### Patch Changes

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/indexer",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @graphtrace/mcp
 
+## 1.8.0
+
+### Minor Changes
+
+- Improve GraphTrace MCP reliability for agentic development workflows.
+
+  - Make MCP workspace resolution prefer explicit `workspaceRoot` and startup cwd before requiring manual workspace ids.
+  - Improve symbol-name-only MCP lookups with disambiguation hints instead of empty graph results.
+  - Add opt-in local MCP telemetry via `GRAPHTRACE_MCP_TELEMETRY=1`.
+
+### Patch Changes
+
+- Updated dependencies
+  - @graphtrace/query-engine@1.8.0
+  - @graphtrace/shared@1.8.0
+  - @graphtrace/server@1.8.0
+  - @graphtrace/storage@1.8.0
+
 ## 1.7.2
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/mcp",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { createGraphTraceDaemon } from "@graphtrace/server";
 import { GRAPHTRACE_DB_PATH, type SymbolLocator } from "@graphtrace/shared";
 import type { WorkspaceRecord } from "@graphtrace/storage";
+import { createMcpTelemetry } from "./telemetry";
 
 function asToolResult(payload: unknown) {
   return {
@@ -34,6 +35,7 @@ interface GraphTraceMcpServerOptions {
 
 interface WorkspaceResolutionHint {
   workspaceId?: string;
+  workspaceRoot?: string;
   target?: string;
   filePath?: string;
   symbolId?: string;
@@ -49,20 +51,127 @@ interface ResolvedWorkspaceContext {
   runIndex(mode: "full" | "incremental"): Promise<unknown>;
 }
 
+type SymbolLocatorInput = {
+  symbolId?: string;
+  filePath?: string;
+  symbolName?: string;
+  line?: number;
+  column?: number;
+};
+
+interface SymbolResolutionRequired {
+  candidates: unknown[];
+  hint: string;
+  resolutionRequired: true;
+}
+
 export async function createGraphTraceMcpServer(
   options: GraphTraceMcpServerOptions = {},
 ) {
   const homeDir = options.homeDir ?? homedir();
   const daemon = createGraphTraceDaemon({ homeDir });
+  const telemetry = createMcpTelemetry({ homeDir });
   const server = new McpServer({
     name: "graphtrace",
     version: "1.0.0",
   });
 
   const withResolvedWorkspace = <T>(
+    toolName: string,
     hint: WorkspaceResolutionHint,
     action: (context: ResolvedWorkspaceContext) => T,
-  ) => action(resolveWorkspaceContext(hint));
+  ): T => {
+    const startedAt = Date.now();
+    let context: ResolvedWorkspaceContext | undefined;
+
+    try {
+      context = resolveWorkspaceContext(hint);
+      const result = action(context);
+      if (isPromiseLike(result)) {
+        return result
+          .then((value) => {
+            recordWorkspaceTelemetry(toolName, startedAt, true, context);
+            return value;
+          })
+          .catch((error: unknown) => {
+            recordWorkspaceTelemetry(
+              toolName,
+              startedAt,
+              false,
+              context,
+              error,
+            );
+            throw error;
+          }) as T;
+      }
+
+      recordWorkspaceTelemetry(toolName, startedAt, true, context);
+      return result;
+    } catch (error) {
+      recordWorkspaceTelemetry(toolName, startedAt, false, context, error);
+      throw error;
+    }
+  };
+
+  const recordWorkspaceTelemetry = (
+    toolName: string,
+    startedAt: number,
+    ok: boolean,
+    context?: ResolvedWorkspaceContext,
+    error?: unknown,
+  ) => {
+    telemetry.record({
+      toolName,
+      ok,
+      durationMs: Date.now() - startedAt,
+      workspaceId: context?.workspaceId,
+      workspaceRoot: context?.workspaceRoot,
+      error: error ? errorToMessage(error) : undefined,
+    });
+  };
+
+  const withToolTelemetry = <T>(toolName: string, action: () => T): T => {
+    const startedAt = Date.now();
+
+    try {
+      const result = action();
+      if (isPromiseLike(result)) {
+        return result
+          .then((value) => {
+            telemetry.record({
+              toolName,
+              ok: true,
+              durationMs: Date.now() - startedAt,
+            });
+            return value;
+          })
+          .catch((error: unknown) => {
+            telemetry.record({
+              toolName,
+              ok: false,
+              durationMs: Date.now() - startedAt,
+              error: errorToMessage(error),
+            });
+            throw error;
+          }) as T;
+      }
+
+      telemetry.record({
+        toolName,
+        ok: true,
+        durationMs: Date.now() - startedAt,
+      });
+      return result;
+    } catch (error) {
+      telemetry.record({
+        toolName,
+        ok: false,
+        durationMs: Date.now() - startedAt,
+        error: errorToMessage(error),
+      });
+      throw error;
+    }
+  };
 
   server.registerTool(
     "list_workspaces",
@@ -71,9 +180,11 @@ export async function createGraphTraceMcpServer(
       inputSchema: {},
     },
     async () =>
-      asToolResult({
-        items: daemon.listWorkspaceSummaries(),
-      }),
+      withToolTelemetry("list_workspaces", () =>
+        asToolResult({
+          items: daemon.listWorkspaceSummaries(),
+        }),
+      ),
   );
 
   server.registerTool(
@@ -85,13 +196,16 @@ export async function createGraphTraceMcpServer(
         label: z.string().optional(),
       },
     },
-    async ({ rootPath, label }) => {
-      const workspace = await daemon.addWorkspace(resolve(rootPath), { label });
-      return asToolResult({
-        workspace,
-        status: daemon.status(workspace.id),
-      });
-    },
+    async ({ rootPath, label }) =>
+      withToolTelemetry("add_workspace", async () => {
+        const workspace = await daemon.addWorkspace(resolve(rootPath), {
+          label,
+        });
+        return asToolResult({
+          workspace,
+          status: daemon.status(workspace.id),
+        });
+      }),
   );
 
   server.registerTool(
@@ -102,13 +216,14 @@ export async function createGraphTraceMcpServer(
         workspaceId: z.string(),
       },
     },
-    async ({ workspaceId }) => {
-      const workspace = await daemon.reindexWorkspace(workspaceId);
-      return asToolResult({
-        workspace,
-        status: daemon.status(workspace.id),
-      });
-    },
+    async ({ workspaceId }) =>
+      withToolTelemetry("reindex_workspace", async () => {
+        const workspace = await daemon.reindexWorkspace(workspaceId);
+        return asToolResult({
+          workspace,
+          status: daemon.status(workspace.id),
+        });
+      }),
   );
 
   server.registerTool(
@@ -119,19 +234,20 @@ export async function createGraphTraceMcpServer(
         workspaceId: z.string(),
       },
     },
-    async ({ workspaceId }) => {
-      const workspace = daemon.getWorkspace(workspaceId);
-      if (!workspace) {
-        throw new Error(`Unknown workspace: ${workspaceId}`);
-      }
+    async ({ workspaceId }) =>
+      withToolTelemetry("remove_workspace", () => {
+        const workspace = daemon.getWorkspace(workspaceId);
+        if (!workspace) {
+          throw new Error(`Unknown workspace: ${workspaceId}`);
+        }
 
-      daemon.removeWorkspace(workspaceId);
-      return asToolResult({
-        removed: true,
-        workspaceId,
-        label: workspace.label,
-      });
-    },
+        daemon.removeWorkspace(workspaceId);
+        return asToolResult({
+          removed: true,
+          workspaceId,
+          label: workspace.label,
+        });
+      }),
   );
 
   server.registerTool(
@@ -142,12 +258,16 @@ export async function createGraphTraceMcpServer(
       inputSchema: {
         query: z.string(),
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
       },
     },
-    async ({ query, workspaceId }) =>
+    async ({ query, workspaceId, workspaceRoot }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) =>
-          context.withQueryEngine((engine) => engine.searchSymbols(query)),
+        withResolvedWorkspace(
+          "graphtrace_search_symbols",
+          { workspaceId, workspaceRoot },
+          (context) =>
+            context.withQueryEngine((engine) => engine.searchSymbols(query)),
         ),
       ),
   );
@@ -159,6 +279,7 @@ export async function createGraphTraceMcpServer(
         "Resolve a symbol by id, file plus name, or file plus position.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         symbolId: z.string().optional(),
         filePath: z.string().optional(),
         symbolName: z.string().optional(),
@@ -166,18 +287,23 @@ export async function createGraphTraceMcpServer(
         column: z.number().int().positive().optional(),
       },
     },
-    async ({ workspaceId, ...locator }) =>
+    async ({ workspaceId, workspaceRoot, ...locator }) =>
       asToolResult(
         withResolvedWorkspace(
+          "graphtrace_get_symbol",
           {
             workspaceId,
+            workspaceRoot,
             filePath: locator.filePath,
             symbolId: locator.symbolId,
           },
           (context) =>
-            context.withQueryEngine((engine) =>
-              engine.getSymbol(toSymbolLocator(locator)),
-            ),
+            context.withQueryEngine((engine) => {
+              const resolvedLocator = resolveSymbolLocator(engine, locator);
+              return isSymbolResolutionRequired(resolvedLocator)
+                ? resolvedLocator
+                : engine.getSymbol(resolvedLocator);
+            }),
         ),
       ),
   );
@@ -189,6 +315,7 @@ export async function createGraphTraceMcpServer(
         "Get upstream callers, downstream callees, and sinks for a symbol.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         symbolId: z.string().optional(),
         filePath: z.string().optional(),
         symbolName: z.string().optional(),
@@ -198,21 +325,26 @@ export async function createGraphTraceMcpServer(
         maxEdges: z.number().int().positive().optional(),
       },
     },
-    async ({ workspaceId, maxNodes, maxEdges, ...locator }) =>
+    async ({ workspaceId, workspaceRoot, maxNodes, maxEdges, ...locator }) =>
       asToolResult(
         withResolvedWorkspace(
+          "graphtrace_get_execution_context",
           {
             workspaceId,
+            workspaceRoot,
             filePath: locator.filePath,
             symbolId: locator.symbolId,
           },
           (context) =>
-            context.withQueryEngine((engine) =>
-              engine.executionContextFromSymbol(toSymbolLocator(locator), {
-                maxNodes,
-                maxEdges,
-              }),
-            ),
+            context.withQueryEngine((engine) => {
+              const resolvedLocator = resolveSymbolLocator(engine, locator);
+              return isSymbolResolutionRequired(resolvedLocator)
+                ? resolvedLocator
+                : engine.executionContextFromSymbol(resolvedLocator, {
+                    maxNodes,
+                    maxEdges,
+                  });
+            }),
         ),
       ),
   );
@@ -224,6 +356,7 @@ export async function createGraphTraceMcpServer(
         "Get an impact-oriented symbol graph with truncation metadata.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         symbolId: z.string().optional(),
         filePath: z.string().optional(),
         symbolName: z.string().optional(),
@@ -233,21 +366,26 @@ export async function createGraphTraceMcpServer(
         maxEdges: z.number().int().positive().optional(),
       },
     },
-    async ({ workspaceId, maxNodes, maxEdges, ...locator }) =>
+    async ({ workspaceId, workspaceRoot, maxNodes, maxEdges, ...locator }) =>
       asToolResult(
         withResolvedWorkspace(
+          "graphtrace_get_symbol_impact",
           {
             workspaceId,
+            workspaceRoot,
             filePath: locator.filePath,
             symbolId: locator.symbolId,
           },
           (context) =>
-            context.withQueryEngine((engine) =>
-              engine.impactFromSymbol(toSymbolLocator(locator), {
-                maxNodes,
-                maxEdges,
-              }),
-            ),
+            context.withQueryEngine((engine) => {
+              const resolvedLocator = resolveSymbolLocator(engine, locator);
+              return isSymbolResolutionRequired(resolvedLocator)
+                ? resolvedLocator
+                : engine.impactFromSymbol(resolvedLocator, {
+                    maxNodes,
+                    maxEdges,
+                  });
+            }),
         ),
       ),
   );
@@ -258,13 +396,17 @@ export async function createGraphTraceMcpServer(
       description: "Explain provenance and confidence for a symbol graph edge.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         edgeId: z.string(),
       },
     },
-    async ({ workspaceId, edgeId }) =>
+    async ({ workspaceId, workspaceRoot, edgeId }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) =>
-          context.withQueryEngine((engine) => engine.explainEdge(edgeId)),
+        withResolvedWorkspace(
+          "graphtrace_explain_edge",
+          { workspaceId, workspaceRoot },
+          (context) =>
+            context.withQueryEngine((engine) => engine.explainEdge(edgeId)),
         ),
       ),
   );
@@ -276,12 +418,16 @@ export async function createGraphTraceMcpServer(
       inputSchema: {
         query: z.string(),
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
       },
     },
-    async ({ query, workspaceId }) =>
+    async ({ query, workspaceId, workspaceRoot }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) =>
-          context.withQueryEngine((engine) => engine.search(query)),
+        withResolvedWorkspace(
+          "search_code",
+          { workspaceId, workspaceRoot },
+          (context) =>
+            context.withQueryEngine((engine) => engine.search(query)),
         ),
       ),
   );
@@ -293,12 +439,16 @@ export async function createGraphTraceMcpServer(
       inputSchema: {
         query: z.string(),
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
       },
     },
-    async ({ query, workspaceId }) =>
+    async ({ query, workspaceId, workspaceRoot }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) =>
-          context.withQueryEngine((engine) => engine.getSymbolContext(query)),
+        withResolvedWorkspace(
+          "get_symbol_context",
+          { workspaceId, workspaceRoot },
+          (context) =>
+            context.withQueryEngine((engine) => engine.getSymbolContext(query)),
         ),
       ),
   );
@@ -309,17 +459,21 @@ export async function createGraphTraceMcpServer(
       description: "Get dependencies for a file path.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         target: z.string(),
         direction: z.enum(["in", "out", "both"]).default("both"),
         depth: z.number().int().positive().default(1),
       },
     },
-    async ({ workspaceId, target, direction, depth }) =>
+    async ({ workspaceId, workspaceRoot, target, direction, depth }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId, target }, (context) =>
-          context.withQueryEngine((engine) =>
-            engine.dependencies(target, direction, depth),
-          ),
+        withResolvedWorkspace(
+          "get_dependencies",
+          { workspaceId, workspaceRoot, target },
+          (context) =>
+            context.withQueryEngine((engine) =>
+              engine.dependencies(target, direction, depth),
+            ),
         ),
       ),
   );
@@ -330,14 +484,18 @@ export async function createGraphTraceMcpServer(
       description: "Get static impact analysis for a file path.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         target: z.string(),
         depth: z.number().int().positive().default(6),
       },
     },
-    async ({ workspaceId, target, depth }) =>
+    async ({ workspaceId, workspaceRoot, target, depth }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId, target }, (context) =>
-          context.withQueryEngine((engine) => engine.impact(target, depth)),
+        withResolvedWorkspace(
+          "get_impact_analysis",
+          { workspaceId, workspaceRoot, target },
+          (context) =>
+            context.withQueryEngine((engine) => engine.impact(target, depth)),
         ),
       ),
   );
@@ -348,14 +506,18 @@ export async function createGraphTraceMcpServer(
       description: "Get route-to-query flow using GraphTrace heuristics.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         target: z.string(),
         depth: z.number().int().positive().default(6),
       },
     },
-    async ({ workspaceId, target, depth }) =>
+    async ({ workspaceId, workspaceRoot, target, depth }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId, target }, (context) =>
-          context.withQueryEngine((engine) => engine.flow(target, depth)),
+        withResolvedWorkspace(
+          "get_data_flow",
+          { workspaceId, workspaceRoot, target },
+          (context) =>
+            context.withQueryEngine((engine) => engine.flow(target, depth)),
         ),
       ),
   );
@@ -366,12 +528,15 @@ export async function createGraphTraceMcpServer(
       description: "List routes discovered in the selected workspace.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
       },
     },
-    async ({ workspaceId }) =>
+    async ({ workspaceId, workspaceRoot }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) =>
-          context.withQueryEngine((engine) => engine.routes()),
+        withResolvedWorkspace(
+          "get_routes",
+          { workspaceId, workspaceRoot },
+          (context) => context.withQueryEngine((engine) => engine.routes()),
         ),
       ),
   );
@@ -382,11 +547,16 @@ export async function createGraphTraceMcpServer(
       description: "Get workspace, database, and last index run status.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
       },
     },
-    async ({ workspaceId }) =>
+    async ({ workspaceId, workspaceRoot }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) => context.status()),
+        withResolvedWorkspace(
+          "get_status",
+          { workspaceId, workspaceRoot },
+          (context) => context.status(),
+        ),
       ),
   );
 
@@ -396,13 +566,16 @@ export async function createGraphTraceMcpServer(
       description: "Run GraphTrace indexing for the selected workspace.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
         mode: z.enum(["full", "incremental"]).default("incremental"),
       },
     },
-    async ({ workspaceId, mode }) =>
+    async ({ workspaceId, workspaceRoot, mode }) =>
       asToolResult(
-        await withResolvedWorkspace({ workspaceId }, (context) =>
-          context.runIndex(mode),
+        await withResolvedWorkspace(
+          "run_index",
+          { workspaceId, workspaceRoot },
+          (context) => context.runIndex(mode),
         ),
       ),
   );
@@ -413,12 +586,16 @@ export async function createGraphTraceMcpServer(
       description: "List packages discovered in the selected workspace.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
       },
     },
-    async ({ workspaceId }) =>
+    async ({ workspaceId, workspaceRoot }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) =>
-          context.withQueryEngine((engine) => engine.listPackages()),
+        withResolvedWorkspace(
+          "list_packages",
+          { workspaceId, workspaceRoot },
+          (context) =>
+            context.withQueryEngine((engine) => engine.listPackages()),
         ),
       ),
   );
@@ -429,12 +606,16 @@ export async function createGraphTraceMcpServer(
       description: "Get the package overview for the selected workspace.",
       inputSchema: {
         workspaceId: z.string().optional(),
+        workspaceRoot: z.string().optional(),
       },
     },
-    async ({ workspaceId }) =>
+    async ({ workspaceId, workspaceRoot }) =>
       asToolResult(
-        withResolvedWorkspace({ workspaceId }, (context) =>
-          context.withQueryEngine((engine) => engine.getPackageOverview()),
+        withResolvedWorkspace(
+          "get_package_overview",
+          { workspaceId, workspaceRoot },
+          (context) =>
+            context.withQueryEngine((engine) => engine.getPackageOverview()),
         ),
       ),
   );
@@ -477,6 +658,24 @@ export async function createGraphTraceMcpServer(
     const registeredWorkspaces = daemon
       .listWorkspaces()
       .filter((workspace) => workspace.status !== "missing");
+
+    if (hint.workspaceRoot) {
+      const matchingWorkspace = selectWorkspaceByRoot(
+        registeredWorkspaces,
+        hint.workspaceRoot,
+      );
+      if (matchingWorkspace) {
+        return createRegisteredContext(matchingWorkspace);
+      }
+    }
+
+    const startupWorkspace = selectWorkspaceByRoot(
+      registeredWorkspaces,
+      options.workspaceRoot,
+    );
+    if (startupWorkspace) {
+      return createRegisteredContext(startupWorkspace);
+    }
 
     if (registeredWorkspaces.length === 1) {
       return createRegisteredContext(registeredWorkspaces[0]);
@@ -584,23 +783,115 @@ function workspaceContainsPath(
   return existsSync(resolve(workspace.canonicalRootPath, pathHint));
 }
 
-function ambiguousWorkspaceError(workspaces: WorkspaceRecord[]): Error {
-  const candidates = workspaces
-    .map((workspace) => `${workspace.id} (${workspace.label})`)
-    .join(", ");
+function selectWorkspaceByRoot(
+  workspaces: WorkspaceRecord[],
+  workspaceRoot: string | undefined,
+): WorkspaceRecord | null {
+  if (!workspaceRoot || workspaceRoot === "/") {
+    return null;
+  }
 
-  return new Error(
-    `GraphTrace MCP could not resolve a workspace automatically. Pass workspaceId. Candidates: ${candidates}`,
+  const resolvedRoot = resolve(workspaceRoot);
+  const matches = workspaces
+    .filter((workspace) =>
+      pathContains(workspace.canonicalRootPath, resolvedRoot),
+    )
+    .sort(
+      (left, right) =>
+        right.canonicalRootPath.length - left.canonicalRootPath.length,
+    );
+
+  return matches[0] ?? null;
+}
+
+function pathContains(parentPath: string, childPath: string): boolean {
+  const resolvedParent = resolve(parentPath);
+  const resolvedChild = resolve(childPath);
+  return (
+    resolvedChild === resolvedParent ||
+    resolvedChild.startsWith(`${resolvedParent}/`)
   );
 }
 
-function toSymbolLocator(input: {
-  symbolId?: string;
-  filePath?: string;
-  symbolName?: string;
-  line?: number;
-  column?: number;
-}): SymbolLocator {
+function ambiguousWorkspaceError(workspaces: WorkspaceRecord[]): Error {
+  const candidates = workspaces
+    .map(
+      (workspace) =>
+        `- ${workspace.id} (${workspace.label}) at ${workspace.canonicalRootPath}`,
+    )
+    .join("\n");
+
+  return new Error(
+    [
+      "GraphTrace MCP could not resolve a workspace automatically.",
+      "Pass workspaceId or workspaceRoot explicitly.",
+      "Registered workspaces:",
+      candidates,
+      "Hint: call list_workspaces, then retry with the selected workspaceId.",
+    ].join("\n"),
+  );
+}
+
+function isPromiseLike<T>(value: T | Promise<T>): value is Promise<T> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    "then" in value &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+function errorToMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function resolveSymbolLocator(
+  engine: ReturnType<typeof createQueryEngine>,
+  input: SymbolLocatorInput,
+): SymbolLocator | SymbolResolutionRequired {
+  if (
+    !input.symbolId &&
+    !input.filePath &&
+    input.symbolName &&
+    typeof input.line !== "number" &&
+    typeof input.column !== "number"
+  ) {
+    const searchResult = engine.searchSymbols(input.symbolName) as {
+      items?: Array<{ id?: string; label?: string; name?: string }>;
+    };
+    const items = searchResult.items ?? [];
+    const exactMatches = items.filter(
+      (item) =>
+        item.name === input.symbolName ||
+        item.label === input.symbolName ||
+        item.id?.endsWith(`#${input.symbolName}`),
+    );
+    const candidates = exactMatches.length > 0 ? exactMatches : items;
+
+    if (candidates.length === 1 && candidates[0].id) {
+      return { symbolId: candidates[0].id };
+    }
+
+    return {
+      candidates: candidates.slice(0, 10),
+      hint:
+        candidates.length === 0
+          ? `No symbol matched ${input.symbolName}. Try graphtrace_search_symbols or search_code first.`
+          : "Pass symbolId or filePath + symbolName to disambiguate.",
+      resolutionRequired: true,
+    };
+  }
+
+  return toSymbolLocator(input);
+}
+
+function isSymbolResolutionRequired(
+  result: SymbolLocator | SymbolResolutionRequired,
+): result is SymbolResolutionRequired {
+  return "resolutionRequired" in result;
+}
+
+function toSymbolLocator(input: SymbolLocatorInput): SymbolLocator {
   if (input.symbolId) {
     return { symbolId: input.symbolId };
   }

--- a/packages/mcp/src/telemetry.ts
+++ b/packages/mcp/src/telemetry.ts
@@ -1,0 +1,54 @@
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+import { buildManagedStorageRoot } from "@graphtrace/storage";
+
+export interface McpTelemetryEvent {
+  toolName: string;
+  ok: boolean;
+  durationMs: number;
+  workspaceId?: string;
+  workspaceRoot?: string;
+  error?: string;
+}
+
+export interface McpTelemetry {
+  enabled: boolean;
+  logPath: string;
+  record(event: McpTelemetryEvent): void;
+}
+
+export function createMcpTelemetry(options: {
+  homeDir: string;
+  env?: NodeJS.ProcessEnv;
+}): McpTelemetry {
+  const env = options.env ?? process.env;
+  const logPath = join(
+    buildManagedStorageRoot(options.homeDir),
+    "mcp-telemetry.jsonl",
+  );
+  const enabled = isTelemetryEnabled(env.GRAPHTRACE_MCP_TELEMETRY);
+
+  return {
+    enabled,
+    logPath,
+    record(event) {
+      if (!enabled) {
+        return;
+      }
+
+      try {
+        mkdirSync(dirname(logPath), { recursive: true });
+        appendFileSync(
+          logPath,
+          `${JSON.stringify({ timestamp: new Date().toISOString(), ...event })}\n`,
+          "utf8",
+        );
+      } catch {}
+    },
+  };
+}
+
+function isTelemetryEnabled(value: string | undefined): boolean {
+  return ["1", "true", "yes", "on"].includes(value?.trim().toLowerCase() ?? "");
+}

--- a/packages/mcp/test/mcp.test.ts
+++ b/packages/mcp/test/mcp.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from "node:fs/promises";
+import { mkdtemp, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -328,7 +328,7 @@ describe("mcp", () => {
             symbolName: "registerSingleWorkspaceRoutes",
           },
         });
-        const ambiguousRoutes = await client.callTool({
+        const cwdRoutes = await client.callTool({
           name: "get_routes",
           arguments: {},
         });
@@ -340,7 +340,6 @@ describe("mcp", () => {
         const autoResolvedItems = readToolItems(
           autoResolvedSymbol.structuredContent,
         );
-        const ambiguousText = readToolText(ambiguousRoutes);
 
         expect(workspaces.isError).not.toBe(true);
         expect(workspaceItems).toEqual(
@@ -361,8 +360,7 @@ describe("mcp", () => {
               item.filePath?.includes("packages/server/src/index.ts"),
           ),
         ).toBe(true);
-        expect(ambiguousRoutes.isError).toBe(true);
-        expect(ambiguousText).toContain("workspaceId");
+        expect(cwdRoutes.isError).not.toBe(true);
       } finally {
         await transport.close().catch(() => undefined);
       }
@@ -614,6 +612,191 @@ describe("mcp", () => {
         ]),
       );
     } finally {
+      await transport.close().catch(() => undefined);
+      daemon.close();
+    }
+  }, 20_000);
+
+  test("prefers the MCP startup cwd when multiple registered workspaces exist", async () => {
+    await ensureWorkspaceInitialized(fixtureRoot);
+    await ensureWorkspaceInitialized(symbolGraphFixtureRoot);
+    await indexWorkspace({ workspaceRoot: fixtureRoot, full: true });
+    await indexWorkspace({ workspaceRoot: symbolGraphFixtureRoot, full: true });
+    const homeDir = await mkdtemp(join(tmpdir(), "graphtrace-mcp-home-"));
+    const daemon = createGraphTraceDaemon({ homeDir });
+
+    const transport = new StdioClientTransport({
+      command: "pnpm",
+      args: [
+        "exec",
+        "node",
+        "--import",
+        "tsx",
+        cliEntry,
+        "mcp",
+        "--home",
+        homeDir,
+      ],
+      cwd: symbolGraphFixtureRoot,
+      stderr: "pipe",
+    });
+    const client = new Client(
+      {
+        name: "graphtrace-test-client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    try {
+      await daemon.addWorkspace(fixtureRoot, { label: "fixture" });
+      await daemon.addWorkspace(symbolGraphFixtureRoot, { label: "symbols" });
+      await client.connect(transport);
+
+      const status = await client.callTool({
+        name: "get_status",
+        arguments: {},
+      });
+      const payload = status.structuredContent as { workspaceRoot?: string };
+
+      expect(status.isError).not.toBe(true);
+      expect(payload.workspaceRoot).toBe(symbolGraphFixtureRoot);
+    } finally {
+      await client.close().catch(() => undefined);
+      await transport.close().catch(() => undefined);
+      daemon.close();
+    }
+  }, 20_000);
+
+  test("resolves unique symbolName-only MCP graph lookups", async () => {
+    await ensureWorkspaceInitialized(symbolGraphFixtureRoot);
+    await indexWorkspace({ workspaceRoot: symbolGraphFixtureRoot, full: true });
+    const homeDir = await mkdtemp(join(tmpdir(), "graphtrace-mcp-home-"));
+    const daemon = createGraphTraceDaemon({ homeDir });
+
+    const transport = new StdioClientTransport({
+      command: "pnpm",
+      args: [
+        "exec",
+        "node",
+        "--import",
+        "tsx",
+        cliEntry,
+        "mcp",
+        "--home",
+        homeDir,
+      ],
+      cwd: symbolGraphFixtureRoot,
+      stderr: "pipe",
+    });
+    const client = new Client(
+      {
+        name: "graphtrace-test-client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    try {
+      await daemon.addWorkspace(symbolGraphFixtureRoot, { label: "symbols" });
+      await client.connect(transport);
+
+      const execution = await client.callTool({
+        name: "graphtrace_get_execution_context",
+        arguments: {
+          symbolName: "listUsers",
+          maxNodes: 10,
+          maxEdges: 10,
+        },
+      });
+      const impact = await client.callTool({
+        name: "graphtrace_get_symbol_impact",
+        arguments: {
+          symbolName: "auditedListUsers",
+          maxNodes: 2,
+          maxEdges: 1,
+        },
+      });
+      const executionPayload = execution.structuredContent as {
+        graph?: { nodes?: Array<{ id?: string; kind?: string }> };
+      };
+      const impactPayload = impact.structuredContent as {
+        graph?: { summary?: { truncated?: { nodeLimitReached?: boolean } } };
+      };
+
+      expect(execution.isError).not.toBe(true);
+      expect(executionPayload.graph?.nodes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            id: "GET /users",
+            kind: "route",
+          }),
+        ]),
+      );
+      expect(impact.isError).not.toBe(true);
+      expect(impactPayload.graph?.summary?.truncated?.nodeLimitReached).toBe(
+        true,
+      );
+    } finally {
+      await client.close().catch(() => undefined);
+      await transport.close().catch(() => undefined);
+      daemon.close();
+    }
+  }, 20_000);
+
+  test("writes opt-in MCP telemetry events", async () => {
+    await ensureWorkspaceInitialized(fixtureRoot);
+    await indexWorkspace({ workspaceRoot: fixtureRoot, full: true });
+    const homeDir = await mkdtemp(join(tmpdir(), "graphtrace-mcp-home-"));
+    const daemon = createGraphTraceDaemon({ homeDir });
+
+    const transport = new StdioClientTransport({
+      command: "pnpm",
+      args: [
+        "exec",
+        "node",
+        "--import",
+        "tsx",
+        cliEntry,
+        "mcp",
+        "--home",
+        homeDir,
+      ],
+      cwd: fixtureRoot,
+      env: {
+        ...process.env,
+        GRAPHTRACE_MCP_TELEMETRY: "1",
+      },
+      stderr: "pipe",
+    });
+    const client = new Client(
+      {
+        name: "graphtrace-test-client",
+        version: "1.0.0",
+      },
+      {
+        capabilities: {},
+      },
+    );
+
+    try {
+      await daemon.addWorkspace(fixtureRoot, { label: "fixture" });
+      await client.connect(transport);
+      await client.callTool({ name: "get_status", arguments: {} });
+      await client.close();
+
+      const telemetry = await readFile(
+        join(homeDir, ".graphtrace", "mcp-telemetry.jsonl"),
+        "utf8",
+      );
+      expect(telemetry).toContain('"toolName":"get_status"');
+      expect(telemetry).toContain('"ok":true');
+    } finally {
+      await client.close().catch(() => undefined);
       await transport.close().catch(() => undefined);
       daemon.close();
     }

--- a/packages/query-engine/CHANGELOG.md
+++ b/packages/query-engine/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @graphtrace/query-engine
 
+## 1.8.0
+
+### Minor Changes
+
+- Add partial-coverage warnings to query results and graph envelopes when workspace units are shallow or unknown.
+
+### Patch Changes
+
+- Updated dependencies
+  - @graphtrace/shared@1.8.0
+  - @graphtrace/indexer@1.8.0
+  - @graphtrace/storage@1.8.0
+
 ## 1.7.2
 
 ### Patch Changes

--- a/packages/query-engine/package.json
+++ b/packages/query-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/query-engine",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/query-engine/src/index.ts
+++ b/packages/query-engine/src/index.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 
 import { indexWorkspace } from "@graphtrace/indexer";
 import type {
+  CoverageSummary,
   DependencyDirection,
   GraphItem,
   QueryResult,
@@ -13,6 +14,47 @@ import type { GraphStore } from "@graphtrace/storage";
 import { openGraphStore } from "@graphtrace/storage";
 
 export function createQueryEngine(store: GraphStore) {
+  const coverage = (): CoverageSummary | undefined => {
+    const partialUnits = store
+      .units()
+      .filter(
+        (unit) => unit.indexingMode !== "full" || unit.language === "unknown",
+      );
+
+    if (partialUnits.length === 0) {
+      return undefined;
+    }
+
+    return {
+      warnings: [
+        {
+          code: "partial-indexing",
+          message:
+            "Some workspace units were indexed as shallow metadata only; results may omit symbols, routes, or edges from those units.",
+          unitIds: partialUnits.map((unit) => unit.id),
+        },
+      ],
+    };
+  };
+
+  const withCoverage = <T>(result: QueryResult<T>): QueryResult<T> => {
+    const coverageSummary = coverage();
+    if (!coverageSummary) {
+      return result;
+    }
+
+    return {
+      ...result,
+      coverage: coverageSummary,
+      graph: result.graph
+        ? {
+            ...result.graph,
+            coverage: coverageSummary,
+          }
+        : result.graph,
+    };
+  };
+
   const resolveSymbol = (locator: SymbolLocator): SymbolDescriptor | null => {
     if ("symbolId" in locator) {
       return store.symbolById(locator.symbolId);
@@ -31,38 +73,39 @@ export function createQueryEngine(store: GraphStore) {
 
   const zeroHopSymbolResult = (
     symbols: SymbolDescriptor[],
-  ): QueryResult<SymbolDescriptor> => ({
-    items: symbols,
-    graph: createGraphEnvelope({
-      nodes: symbols.map(toSymbolGraphItem),
-      summary: {
-        nodeCount: symbols.length,
-        edgeCount: 0,
-        rootNodeIds: symbols.map((symbol) => symbol.id),
-        confidence: {},
-      },
-    }),
-  });
+  ): QueryResult<SymbolDescriptor> =>
+    withCoverage({
+      items: symbols,
+      graph: createGraphEnvelope({
+        nodes: symbols.map(toSymbolGraphItem),
+        summary: {
+          nodeCount: symbols.length,
+          edgeCount: 0,
+          rootNodeIds: symbols.map((symbol) => symbol.id),
+          confidence: {},
+        },
+      }),
+    });
 
   return {
     search(query: string, kind?: string) {
-      return store.search(query, kind);
+      return withCoverage(store.search(query, kind));
     },
     searchByRepository(repositoryId: string, query: string, kind?: string) {
-      return store.searchByRepository(repositoryId, query, kind);
+      return withCoverage(store.searchByRepository(repositoryId, query, kind));
     },
     routes(packageName?: string) {
-      return store.routes(packageName);
+      return withCoverage(store.routes(packageName));
     },
     routesByRepository(repositoryId: string, packageName?: string) {
-      return store.routesByRepository(repositoryId, packageName);
+      return withCoverage(store.routesByRepository(repositoryId, packageName));
     },
     dependencies(
       target: string,
       direction: DependencyDirection = "both",
       depth = 1,
     ) {
-      return store.fileDependencies(target, direction, depth);
+      return withCoverage(store.fileDependencies(target, direction, depth));
     },
     dependenciesByRepository(
       repositoryId: string,
@@ -70,24 +113,30 @@ export function createQueryEngine(store: GraphStore) {
       direction: DependencyDirection = "both",
       depth = 1,
     ) {
-      return store.fileDependenciesByRepository(
-        repositoryId,
-        target,
-        direction,
-        depth,
+      return withCoverage(
+        store.fileDependenciesByRepository(
+          repositoryId,
+          target,
+          direction,
+          depth,
+        ),
       );
     },
     impact(target: string, depth = 6) {
-      return store.impactFromPath(target, depth);
+      return withCoverage(store.impactFromPath(target, depth));
     },
     impactByRepository(repositoryId: string, target: string, depth = 6) {
-      return store.impactFromPathByRepository(repositoryId, target, depth);
+      return withCoverage(
+        store.impactFromPathByRepository(repositoryId, target, depth),
+      );
     },
     flow(target: string, depth = 6) {
-      return store.flowFromRoute(target, depth);
+      return withCoverage(store.flowFromRoute(target, depth));
     },
     flowByRepository(repositoryId: string, target: string, depth = 6) {
-      return store.flowFromRouteByRepository(repositoryId, target, depth);
+      return withCoverage(
+        store.flowFromRouteByRepository(repositoryId, target, depth),
+      );
     },
     listPackages() {
       return store.packageOverview();
@@ -104,7 +153,7 @@ export function createQueryEngine(store: GraphStore) {
       };
     },
     getSymbolContext(query: string) {
-      return store.search(query);
+      return withCoverage(store.search(query));
     },
     searchSymbols(query: string) {
       return zeroHopSymbolResult(
@@ -122,17 +171,17 @@ export function createQueryEngine(store: GraphStore) {
       const symbol = resolveSymbol(locator);
 
       if (!symbol) {
-        return {
+        return withCoverage({
           items: [],
           graph: createGraphEnvelope(),
-        };
+        });
       }
 
       const graph = store.symbolNeighbors(symbol.id);
-      return {
+      return withCoverage({
         items: graph.nodes,
         graph,
-      };
+      });
     },
     executionContextFromSymbol(
       locator: SymbolLocator,
@@ -141,17 +190,17 @@ export function createQueryEngine(store: GraphStore) {
       const symbol = resolveSymbol(locator);
 
       if (!symbol) {
-        return {
+        return withCoverage({
           items: [],
           graph: createGraphEnvelope(),
-        };
+        });
       }
 
       const graph = store.executionContextFromSymbol(symbol.id, options);
-      return {
+      return withCoverage({
         items: graph.nodes,
         graph,
-      };
+      });
     },
     impactFromSymbol(
       locator: SymbolLocator,
@@ -160,17 +209,17 @@ export function createQueryEngine(store: GraphStore) {
       const symbol = resolveSymbol(locator);
 
       if (!symbol) {
-        return {
+        return withCoverage({
           items: [],
           graph: createGraphEnvelope(),
-        };
+        });
       }
 
       const graph = store.impactFromSymbol(symbol.id, options);
-      return {
+      return withCoverage({
         items: graph.nodes,
         graph,
-      };
+      });
     },
     explainEdge(edgeId: string) {
       return store.explainEdge(edgeId);

--- a/packages/query-engine/test/query-engine.test.ts
+++ b/packages/query-engine/test/query-engine.test.ts
@@ -25,6 +25,7 @@ const laravelResourceFixtureRoot = join(
   "laravel-resource-workspace",
 );
 const laravelFixtureRoot = join(process.cwd(), "fixtures", "laravel-workspace");
+const mixedFixtureRoot = join(process.cwd(), "fixtures", "mixed-workspace");
 const crudboosterLegacyFixtureRoot = join(
   process.cwd(),
   "fixtures",
@@ -121,6 +122,36 @@ describe("query engine", () => {
           edgeCount: expect.any(Number),
         }),
       });
+    } finally {
+      store.close();
+    }
+  });
+
+  test("query results warn when workspace coverage is shallow", async () => {
+    await ensureWorkspaceInitialized(mixedFixtureRoot);
+    await indexWorkspace({ workspaceRoot: mixedFixtureRoot, full: true });
+
+    const store = openGraphStore(
+      join(mixedFixtureRoot, ".graphtrace", "index.db"),
+    );
+
+    try {
+      const result = createQueryEngine(store).search("server");
+
+      expect(result.coverage?.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            code: "partial-indexing",
+          }),
+        ]),
+      );
+      expect(result.graph?.coverage?.warnings).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            unitIds: expect.arrayContaining(["unit:workers/python"]),
+          }),
+        ]),
+      );
     } finally {
       store.close();
     }

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @graphtrace/server
 
+## 1.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @graphtrace/query-engine@1.8.0
+  - @graphtrace/shared@1.8.0
+  - @graphtrace/storage@1.8.0
+
 ## 1.7.2
 
 ### Patch Changes

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/server",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @graphtrace/shared
 
+## 1.8.0
+
+### Minor Changes
+
+- Add shared coverage metadata types for query results and graph envelopes.
+
 ## 1.7.2
 
 ## 1.7.1

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/shared",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -143,6 +143,17 @@ export interface GraphItem {
 export interface QueryResult<T> {
   items: T[];
   graph?: GraphEnvelope;
+  coverage?: CoverageSummary;
+}
+
+export interface CoverageWarning {
+  code: string;
+  message: string;
+  unitIds: string[];
+}
+
+export interface CoverageSummary {
+  warnings: CoverageWarning[];
 }
 
 export interface GraphEdgeDescriptor {
@@ -175,6 +186,7 @@ export interface GraphEnvelope {
   nodes: GraphItem[];
   edges: GraphEdgeDescriptor[];
   summary: GraphEnvelopeSummary;
+  coverage?: CoverageSummary;
 }
 
 export type SymbolLocator =
@@ -200,6 +212,7 @@ export function createGraphEnvelope(
       confidence,
       truncated: input.summary?.truncated,
     },
+    coverage: input.coverage,
   };
 }
 

--- a/packages/storage/CHANGELOG.md
+++ b/packages/storage/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @graphtrace/storage
 
+## 1.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @graphtrace/shared@1.8.0
+
 ## 1.7.2
 
 ### Patch Changes

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@graphtrace/storage",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Implements the P0-P3 GraphTrace MCP reliability plan for agentic development workflows.

- P0: add `graphtrace agent doctor` for MCP setup/version diagnostics.
- P1: improve MCP workspace resolution with explicit `workspaceRoot`, startup cwd preference, clearer ambiguity errors.
- P2: improve symbol-name-only MCP lookups and add partial-coverage warnings for shallow/unknown units.
- P3: add `graphtrace analyze-sessions` plus opt-in local MCP telemetry via `GRAPHTRACE_MCP_TELEMETRY=1`.
- Release: bump workspace package versions/changelogs to `1.8.0` because npm latest is already `1.7.2`.

Closes #57
Closes #58
Closes #59
Closes #60

## Verification

- `pnpm lint`
- `pnpm release:check-versions`
- `pnpm typecheck`
- `pnpm test` (163 tests)
- `pnpm build`
- `pnpm test:smoke`

## Notes

- Local `npm whoami` currently returns `E401`, so npm publish needs an authenticated npm session/token after merge.
